### PR TITLE
fixing colab links

### DIFF
--- a/examples/parse/advanced_rag/dynamic_section_retrieval.ipynb
+++ b/examples/parse/advanced_rag/dynamic_section_retrieval.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Dynamic Section Retrieval with LlamaParse\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llamacloud-demo/blob/main/examples/advanced_rag/dynamic_section_retrieval.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llamacloud-demo/blob/main/examples/parse/advanced_rag/dynamic_section_retrieval.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook showcases a concept called \"dynamic section retrieval\".\n",
     "\n",

--- a/examples/parse/advanced_rag/dynamic_section_retrieval.ipynb
+++ b/examples/parse/advanced_rag/dynamic_section_retrieval.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Dynamic Section Retrieval with LlamaParse\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llamacloud-demo/blob/main/examples/parse/advanced_rag/dynamic_section_retrieval.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services-demo/blob/main/examples/parse/advanced_rag/dynamic_section_retrieval.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook showcases a concept called \"dynamic section retrieval\".\n",
     "\n",

--- a/examples/parse/caltrain/caltrain_text_mode.ipynb
+++ b/examples/parse/caltrain/caltrain_text_mode.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# RAG over the Caltrain Weekend Schedule \n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/caltrain/caltrain_text_mode.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/caltrain/caltrain_text_mode.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This example shows off LlamaParse parsing capabilities to build a functioning query pipeline over the Caltrain weekend schedule, a big timetable containing all trains northbound and southbound and their stops in various cities.\n",
     "\n",

--- a/examples/parse/caltrain/caltrain_text_mode.ipynb
+++ b/examples/parse/caltrain/caltrain_text_mode.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# RAG over the Caltrain Weekend Schedule \n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/caltrain/caltrain_text_mode.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/caltrain/caltrain_text_mode.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This example shows off LlamaParse parsing capabilities to build a functioning query pipeline over the Caltrain weekend schedule, a big timetable containing all trains northbound and southbound and their stops in various cities.\n",
     "\n",

--- a/examples/parse/demo_advanced_weaviate.ipynb
+++ b/examples/parse/demo_advanced_weaviate.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Advanced RAG with LlamaParse + Weaviate\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_advanced_weaviate.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\\\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/demo_advanced_weaviate.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\\\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook shows you how to use `LlamaParse` for advancd RAG applications with `LlamaIndex` and [Weaviate](https://weaviate.io/).\n",
     "\n",

--- a/examples/parse/demo_excel.ipynb
+++ b/examples/parse/demo_excel.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# RAG with Excel Spreadsheet using LlamaPrase\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_excel.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/demo_excel.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook shows you using LlamaParse with Excel Spreadsheet.\n",
     "\n",

--- a/examples/parse/demo_get_charts.ipynb
+++ b/examples/parse/demo_get_charts.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Download Charts\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_get_charts.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/demo_get_charts.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook demonstrates how to download charts from a document using the JSON mode in LlamaParse.\n",
     "\n",

--- a/examples/parse/demo_insurance.ipynb
+++ b/examples/parse/demo_insurance.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# LlamaParse - Fast checking Insurance Contract for Coverage\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_insurance.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/demo_insurance.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "In this notebook we will look at how LlamaParse can be used to extract structured coverage information from an insurance policy."
    ]

--- a/examples/parse/demo_json.ipynb
+++ b/examples/parse/demo_json.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# LlamaParse JSON Mode + Multimodal RAG\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_json.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/demo_json.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook shows you how to use LlamaParse JSON mode with LlamaIndex to build a simple multimodal RAG pipeline.\n",
     "\n",

--- a/examples/parse/demo_json.ipynb
+++ b/examples/parse/demo_json.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# LlamaParse JSON Mode + Multimodal RAG\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/demo_json.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/demo_json.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook shows you how to use LlamaParse JSON mode with LlamaIndex to build a simple multimodal RAG pipeline.\n",
     "\n",

--- a/examples/parse/demo_json_parsing.ipynb
+++ b/examples/parse/demo_json_parsing.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# LlamaParse JSON Mode + Advanced RAG with `LlamaParseJsonNodeParser`\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_json_parsing.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/demo_json_parsing.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook shows you how to use LlamaParse JSON mode with LlamaIndex to build a simple recursive retrieval RAG pipeline using `LlamaParseJsonNodeParser`.\n",
     "\n",

--- a/examples/parse/demo_json_tour.ipynb
+++ b/examples/parse/demo_json_tour.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# LlamaParse JSON Mode Tour\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_json.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/demo_json.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook shows you how to use LlamaParse JSON mode with LlamaIndex and all the features it supports.\n",
     "\n",

--- a/examples/parse/demo_languages.ipynb
+++ b/examples/parse/demo_languages.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "LlamaParse supports users to specify a `language` parameter before uploading documents, giving users better OCR capabilities over non-English PDFs, parsing images into more accurate representations.\n",
     "\n",
-    "You can specify 80+ different languages: see this file for a full list of supported languages: https://github.com/run-llama/llama_parse/blob/main/llama_parse/base.py.\n",
+    "You can specify 80+ different languages: see this file for a full list of supported languages: https://github.com/run-llama/llama_cloud_services/blob/main/llama_parse/base.py.\n",
     "\n",
     "This notebook shows a demo of this in action. "
    ]

--- a/examples/parse/demo_mongodb.ipynb
+++ b/examples/parse/demo_mongodb.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# LlamaParse With MongoDB\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_mongodb.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/demo_mongodb.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "In this notebook, we provide a straightforward example of using LlamaParse with MongoDB Atlas VectorSearch.\n",
     "\n",

--- a/examples/parse/demo_mongodb.ipynb
+++ b/examples/parse/demo_mongodb.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# LlamaParse With MongoDB\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/demo_mongodb.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/demo_mongodb.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "In this notebook, we provide a straightforward example of using LlamaParse with MongoDB Atlas VectorSearch.\n",
     "\n",

--- a/examples/parse/demo_starter_multimodal.ipynb
+++ b/examples/parse/demo_starter_multimodal.ipynb
@@ -5,7 +5,7 @@
    "id": "97c79c38-38a3-40f3-ba2e-250649347d63",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/demo_starter_multimodal.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/demo_starter_multimodal.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/examples/parse/demo_starter_multimodal.ipynb
+++ b/examples/parse/demo_starter_multimodal.ipynb
@@ -5,7 +5,7 @@
    "id": "97c79c38-38a3-40f3-ba2e-250649347d63",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_starter_multimodal.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/demo_starter_multimodal.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/examples/parse/demo_starter_parse_selected_pages.ipynb
+++ b/examples/parse/demo_starter_parse_selected_pages.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/demo_starter_parse_selected_pages.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/demo_starter_parse_selected_pages.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/examples/parse/demo_starter_parse_selected_pages.ipynb
+++ b/examples/parse/demo_starter_parse_selected_pages.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_starter_parse_selected_pages.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/demo_starter_parse_selected_pages.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/examples/parse/demo_table_comparisons.ipynb
+++ b/examples/parse/demo_table_comparisons.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# RAG for Table Comparisons with LlamaParse + LlamaIndex\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_table_comparisons.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/demo_table_comparisons.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook shows you how to do comparisons across both tabular and text data across multiple PDF documents.\n",
     "\n",

--- a/examples/parse/demo_table_comparisons.ipynb
+++ b/examples/parse/demo_table_comparisons.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# RAG for Table Comparisons with LlamaParse + LlamaIndex\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/demo_table_comparisons.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/demo_table_comparisons.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook shows you how to do comparisons across both tabular and text data across multiple PDF documents.\n",
     "\n",

--- a/examples/parse/excel/dcf_rag.ipynb
+++ b/examples/parse/excel/dcf_rag.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# RAG with Excel Spreadsheet using LlamaPrase\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_excel.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/excel/dcf_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook constructs a RAG pipeline over a simple DCF template [here](https://eqvista.com/app/uploads/2020/09/Eqvista_DCF-Excel-Template.xlsx).\n",
     "\n"

--- a/examples/parse/excel/dcf_rag.ipynb
+++ b/examples/parse/excel/dcf_rag.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# RAG with Excel Spreadsheet using LlamaPrase\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/excel/dcf_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/excel/dcf_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook constructs a RAG pipeline over a simple DCF template [here](https://eqvista.com/app/uploads/2020/09/Eqvista_DCF-Excel-Template.xlsx).\n",
     "\n"

--- a/examples/parse/excel/o1_excel_rag.ipynb
+++ b/examples/parse/excel/o1_excel_rag.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/excel/o1_excel_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/excel/o1_excel_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/examples/parse/knowledge_graphs/kg_agent.ipynb
+++ b/examples/parse/knowledge_graphs/kg_agent.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Knowledge Graph Agent with LlamaParse\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/knowledge_graphs/kg_agent.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/knowledge_graphs/kg_agent.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "Here we build a knowledge graph agent over the SF 2023 Budget Proposal. We use LlamaIndex abstractions to construct a knowledge graph, and we store the property graph in neo4j. We then build an agent that can interact with the knowledge graph as a tool."
    ]

--- a/examples/parse/knowledge_graphs/kg_agent.ipynb
+++ b/examples/parse/knowledge_graphs/kg_agent.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Knowledge Graph Agent with LlamaParse\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/knowledge_graphs/kg_agent.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/knowledge_graphs/kg_agent.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "Here we build a knowledge graph agent over the SF 2023 Budget Proposal. We use LlamaIndex abstractions to construct a knowledge graph, and we store the property graph in neo4j. We then build an agent that can interact with the knowledge graph as a tool."
    ]

--- a/examples/parse/multimodal/claude_parse.ipynb
+++ b/examples/parse/multimodal/claude_parse.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Multimodal Parsing using Anthropic Claude (Sonnet 3.5)\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/claude_parse.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/multimodal/claude_parse.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This cookbook shows you how to use LlamaParse to parse any document with the multimodal capabilities of Sonnet 3.5. \n",
     "\n",

--- a/examples/parse/multimodal/claude_parse.ipynb
+++ b/examples/parse/multimodal/claude_parse.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Multimodal Parsing using Anthropic Claude (Sonnet 3.5)\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/multimodal/claude_parse.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/claude_parse.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This cookbook shows you how to use LlamaParse to parse any document with the multimodal capabilities of Sonnet 3.5. \n",
     "\n",

--- a/examples/parse/multimodal/gemini2_flash.ipynb
+++ b/examples/parse/multimodal/gemini2_flash.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Multimodal Parsing with Gemini 2.0 Flash\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/gemini2_flash.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/multimodal/gemini2_flash.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This cookbook shows you how to use LlamaParse to parse any document with the multimodal capabilities of Gemini 2.0 Flash.\n",
     "\n",

--- a/examples/parse/multimodal/gemini2_flash.ipynb
+++ b/examples/parse/multimodal/gemini2_flash.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Multimodal Parsing with Gemini 2.0 Flash\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/multimodal/gemini2_flash.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/gemini2_flash.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This cookbook shows you how to use LlamaParse to parse any document with the multimodal capabilities of Gemini 2.0 Flash.\n",
     "\n",

--- a/examples/parse/multimodal/gpt4o_mini.ipynb
+++ b/examples/parse/multimodal/gpt4o_mini.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Multimodal Parsing using GPT4o-mini\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/multimodal/gpt4o_mini.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/gpt4o_mini.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This cookbook shows you how to use LlamaParse to parse any document with the multimodal capabilities of GPT4o-mini.\n",
     "\n",

--- a/examples/parse/multimodal/gpt4o_mini.ipynb
+++ b/examples/parse/multimodal/gpt4o_mini.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Multimodal Parsing using GPT4o-mini\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/gpt4o_mini.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/multimodal/gpt4o_mini.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This cookbook shows you how to use LlamaParse to parse any document with the multimodal capabilities of GPT4o-mini.\n",
     "\n",

--- a/examples/parse/multimodal/insurance_rag.ipynb
+++ b/examples/parse/multimodal/insurance_rag.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Building a Multimodal RAG Pipeline over an Auto Insurance Claim\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/multimodal/insurance_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/insurance_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/examples/parse/multimodal/insurance_rag.ipynb
+++ b/examples/parse/multimodal/insurance_rag.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Building a Multimodal RAG Pipeline over an Auto Insurance Claim\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/insurance_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/multimodal/insurance_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/examples/parse/multimodal/legal_rag.ipynb
+++ b/examples/parse/multimodal/legal_rag.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Building a RAG Pipeline over Legal Documents\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/multimodal/legal_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/legal_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This example shows how LlamaParse and LlamaIndex can be used to parse various types of legal documents, which may contain complex tabular data. The advantage of this is being able to quickly retrieve a specific answer to a legal question with comprehensive context — knowledge of precedents, statutes, and cases presented in the given documents. A user can quickly find the answer to or find out more details about a specific legal question without having to read through the often long documents by using LLMs.\n",
     "\n",

--- a/examples/parse/multimodal/legal_rag.ipynb
+++ b/examples/parse/multimodal/legal_rag.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Building a RAG Pipeline over Legal Documents\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/legal_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/multimodal/legal_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This example shows how LlamaParse and LlamaIndex can be used to parse various types of legal documents, which may contain complex tabular data. The advantage of this is being able to quickly retrieve a specific answer to a legal question with comprehensive context — knowledge of precedents, statutes, and cases presented in the given documents. A user can quickly find the answer to or find out more details about a specific legal question without having to read through the often long documents by using LLMs.\n",
     "\n",

--- a/examples/parse/multimodal/multimodal_contextual_retrieval_rag.ipynb
+++ b/examples/parse/multimodal/multimodal_contextual_retrieval_rag.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Contextual Retrieval for Multimodal RAG\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/multimodal/multimodal_contextual_retrieval_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/multimodal_contextual_retrieval_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "In this cookbook we show you how to build a multimodal RAG pipeline with **contextual retrieval**.\n",
     "\n",

--- a/examples/parse/multimodal/multimodal_contextual_retrieval_rag.ipynb
+++ b/examples/parse/multimodal/multimodal_contextual_retrieval_rag.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Contextual Retrieval for Multimodal RAG\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/multimodal_contextual_retrieval_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/multimodal/multimodal_contextual_retrieval_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "In this cookbook we show you how to build a multimodal RAG pipeline with **contextual retrieval**.\n",
     "\n",

--- a/examples/parse/multimodal/multimodal_rag_slide_deck.ipynb
+++ b/examples/parse/multimodal/multimodal_rag_slide_deck.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Building a Natively Multimodal RAG Pipeline (over a Slide Deck)\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/multimodal_rag_slide_deck.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/multimodal/multimodal_rag_slide_deck.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "In this cookbook we show you how to build a multimodal RAG pipeline over a slide deck, with text, tables, images, diagrams, and complex layouts.\n",
     "\n",

--- a/examples/parse/multimodal/multimodal_rag_slide_deck.ipynb
+++ b/examples/parse/multimodal/multimodal_rag_slide_deck.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Building a Natively Multimodal RAG Pipeline (over a Slide Deck)\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/multimodal/multimodal_rag_slide_deck.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/multimodal_rag_slide_deck.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "In this cookbook we show you how to build a multimodal RAG pipeline over a slide deck, with text, tables, images, diagrams, and complex layouts.\n",
     "\n",

--- a/examples/parse/multimodal/multimodal_report_generation.ipynb
+++ b/examples/parse/multimodal/multimodal_report_generation.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Multimodal Report Generation (from a Slide Deck)\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/multimodal/multimodal_report_generation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/multimodal_report_generation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "In this cookbook we show you how to build a multimodal report generator. The pipeline parses a slide deck and stores both text and image chunks. It generates a detailed response that contains interleaving text and images.\n",
     "\n",

--- a/examples/parse/multimodal/multimodal_report_generation.ipynb
+++ b/examples/parse/multimodal/multimodal_report_generation.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Multimodal Report Generation (from a Slide Deck)\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/multimodal_report_generation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/multimodal/multimodal_report_generation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "In this cookbook we show you how to build a multimodal report generator. The pipeline parses a slide deck and stores both text and image chunks. It generates a detailed response that contains interleaving text and images.\n",
     "\n",

--- a/examples/parse/multimodal/multimodal_report_generation_agent.ipynb
+++ b/examples/parse/multimodal/multimodal_report_generation_agent.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Multimodal Report Generation Agent \n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/multimodal/multimodal_report_generation_agent.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/multimodal_report_generation_agent.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "In this cookbook we show you how to build a multimodal report generation agent from a bank of research reports. We use the a set of ICLR papers (which were also used as the dataset in our [DeepLearning.ai course](https://www.deeplearning.ai/short-courses/building-agentic-rag-with-llamaindex/?utm_campaign=llamaindexC2-launch&utm_medium=headband&utm_source=dlai-homepage).\n",
     "\n",

--- a/examples/parse/multimodal/multimodal_report_generation_agent.ipynb
+++ b/examples/parse/multimodal/multimodal_report_generation_agent.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Multimodal Report Generation Agent \n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/multimodal_report_generation_agent.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/multimodal/multimodal_report_generation_agent.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "In this cookbook we show you how to build a multimodal report generation agent from a bank of research reports. We use the a set of ICLR papers (which were also used as the dataset in our [DeepLearning.ai course](https://www.deeplearning.ai/short-courses/building-agentic-rag-with-llamaindex/?utm_campaign=llamaindexC2-launch&utm_medium=headband&utm_source=dlai-homepage).\n",
     "\n",

--- a/examples/parse/multimodal/product_manual_rag.ipynb
+++ b/examples/parse/multimodal/product_manual_rag.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Building a RAG Pipeline over IKEA Product Instruction Manuals\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/product_manual_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/multimodal/product_manual_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/examples/parse/multimodal/product_manual_rag.ipynb
+++ b/examples/parse/multimodal/product_manual_rag.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Building a RAG Pipeline over IKEA Product Instruction Manuals\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/multimodal/product_manual_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/multimodal/product_manual_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/examples/parse/parsing_instructions/parsing_instructions.ipynb
+++ b/examples/parse/parsing_instructions/parsing_instructions.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parsing_instructions.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/parsing_instructions.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "# Parsing documents with Instructions\n",
     "\n",

--- a/examples/parse/parsing_instructions/parsing_instructions.ipynb
+++ b/examples/parse/parsing_instructions/parsing_instructions.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/parsing_instructions.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/parsing_instructions.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "# Parsing documents with Instructions\n",
     "\n",

--- a/examples/parse/parsing_modes/demo_auto_mode.ipynb
+++ b/examples/parse/parsing_modes/demo_auto_mode.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Cost-Optimized Parsing with Auto-Mode\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/demo_auto_mode.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/parsing_modes/demo_auto_mode.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "![](diagram.jpg)\n",
     "\n",

--- a/examples/parse/parsing_modes/demo_auto_mode.ipynb
+++ b/examples/parse/parsing_modes/demo_auto_mode.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Cost-Optimized Parsing with Auto-Mode\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/parsing_modes/demo_auto_mode.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/parsing_modes/demo_auto_mode.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "![](diagram.jpg)\n",
     "\n",
@@ -735,7 +735,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, these pages aren't going to be that different when parsed, but we can verify which pages triggered auto-made by looking at the [JSON output](https://github.com/run-llama/llama_parse/blob/main/examples/demo_json_tour.ipynb) of LlamaParse:"
+    "In this example, these pages aren't going to be that different when parsed, but we can verify which pages triggered auto-made by looking at the [JSON output](https://github.com/run-llama/llama_cloud_services/blob/main/examples/demo_json_tour.ipynb) of LlamaParse:"
    ]
   },
   {

--- a/examples/parse/report_generation/rfp_response/generate_rfp.ipynb
+++ b/examples/parse/report_generation/rfp_response/generate_rfp.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# RFP Response Generation Workflow\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/report_generation/rfp_response/generate_rfp.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/report_generation/rfp_response/generate_rfp.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook shows you how to build a workflow to generate a response to an RFP. \n",
     "\n",
@@ -20,7 +20,7 @@
     "\n",
     "We use LlamaParse to parse the context documents as well as the RFP document itself.\n",
     "\n",
-    "**NOTE**: If you want to skip the indexing complexity and use LlamaCloud instead, check out the [RFP Example using LlamaCloud](https://github.com/run-llama/llamacloud-demo/blob/main/examples/report_generation/rfp_response/generate_rfp.ipynb)."
+    "**NOTE**: If you want to skip the indexing complexity and use LlamaCloud instead, check out the [RFP Example using LlamaCloud](https://github.com/run-llama/llama_cloud_services-demo/blob/main/examples/report_generation/rfp_response/generate_rfp.ipynb)."
    ]
   },
   {

--- a/examples/parse/report_generation/rfp_response/generate_rfp.ipynb
+++ b/examples/parse/report_generation/rfp_response/generate_rfp.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# RFP Response Generation Workflow\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/report_generation/rfp_response/generate_rfp.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/report_generation/rfp_response/generate_rfp.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "This notebook shows you how to build a workflow to generate a response to an RFP. \n",
     "\n",

--- a/examples/parse/test_tesla_impact_report/test_gpt4o.ipynb
+++ b/examples/parse/test_tesla_impact_report/test_gpt4o.ipynb
@@ -8,7 +8,7 @@
     "# LlamaParse with GPT-4o\n",
     "\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/test_tesla_impact_report/test_gpt4o.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/test_tesla_impact_report/test_gpt4o.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "GPT-4o is a [fully multimodal model by OpenAI](https://openai.com/index/hello-gpt-4o/) released in May 2024. It matches GPT-4 Turbo performance in text and code, and has significantly improved vision and audio capabilities.\n",
     "\n",

--- a/examples/parse/test_tesla_impact_report/test_gpt4o.ipynb
+++ b/examples/parse/test_tesla_impact_report/test_gpt4o.ipynb
@@ -8,7 +8,7 @@
     "# LlamaParse with GPT-4o\n",
     "\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_parse/blob/main/examples/parse/test_tesla_impact_report/test_gpt4o.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_cloud_services/blob/main/examples/parse/test_tesla_impact_report/test_gpt4o.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "GPT-4o is a [fully multimodal model by OpenAI](https://openai.com/index/hello-gpt-4o/) released in May 2024. It matches GPT-4 Turbo performance in text and code, and has significantly improved vision and audio capabilities.\n",
     "\n",

--- a/llama_parse/README.md
+++ b/llama_parse/README.md
@@ -146,9 +146,9 @@ Full documentation for `SimpleDirectoryReader` can be found on the [LlamaIndex D
 
 Several end-to-end indexing examples can be found in the examples folder
 
-- [Getting Started](examples/demo_basic.ipynb)
-- [Advanced RAG Example](examples/demo_advanced.ipynb)
-- [Raw API Usage](examples/demo_api.ipynb)
+- [Getting Started](/examples/parse/demo_basic.ipynb)
+- [Advanced RAG Example](/examples/parse/demo_advanced.ipynb)
+- [Raw API Usage](/examples/parse/demo_api.ipynb)
 
 ## Documentation
 


### PR DESCRIPTION
The links to open notebooks in colab broke when the `parse` folder was created. I updated these links wherever I could find them.