### PR TITLE
parse: fix the "model" parameter mismatch between playground and Python client

### DIFF
--- a/llama_cloud_services/parse/base.py
+++ b/llama_cloud_services/parse/base.py
@@ -414,6 +414,10 @@ class LlamaParse(BasePydanticReader):
         default=None,
         description="The model name for the vendor multimodal API.",
     )
+    model: Optional[str] = Field(
+        default=None,
+        description="The document model name to be used with `parse_with_agent`.",
+    )
     webhook_url: Optional[str] = Field(
         default=None,
         description="A URL that needs to be called at the end of the parsing job.",
@@ -853,6 +857,9 @@ class LlamaParse(BasePydanticReader):
 
         if self.vendor_multimodal_model_name is not None:
             data["vendor_multimodal_model_name"] = self.vendor_multimodal_model_name
+
+        if self.model is not None:
+            data["model"] = self.model
 
         if self.webhook_url is not None:
             data["webhook_url"] = self.webhook_url


### PR DESCRIPTION
Adds a `model` parameter to the Python client, allowing users to select the document model when using `parse_with_agent`, matching the llamaparse playground functionality.

**Evidence**:
- The playground UI allows selecting a document model in `parse_with_agent` mode (see screenshot 1).
- The selected model in the playground is set in the `model` parameter internally (see screenshot 2).
- The `model` parameter is not used anywhere in the Python client.

**Screenshots**:
- ![Screenshot 1](https://github.com/user-attachments/assets/ad9611f5-de09-4ec4-adfc-a9726f95da6b)
- ![Screenshot 2](https://github.com/user-attachments/assets/d2920ac3-7f9c-4cc3-8960-99da1fefe613)
