### PR TITLE
0.6.28: fix job result format after partitioning changes

### DIFF
--- a/llama_cloud_services/parse/base.py
+++ b/llama_cloud_services/parse/base.py
@@ -1102,20 +1102,27 @@ class LlamaParse(BasePydanticReader):
             try:
                 # Fetch JSON result type first to get accurate pagination data
                 # and then fetch the user's desired result type if needed
-                job_id, job_result = await self._parse_one_unpartitioned(
+                job_id, json_result = await self._parse_one_unpartitioned(
                     file_path,
                     extra_info=extra_info,
                     fs=fs,
                     result_type=ResultType.JSON.value,
                     partition_target_pages=f"{total}-{total + size - 1}",
                 )
+                result_type = result_type or self.result_type.value
+                if result_type == ResultType.JSON.value:
+                    job_result = json_result
+                else:
+                    job_result = await self._get_job_result(
+                        job_id, result_type, verbose=self.verbose
+                    )
             except JobFailedException as e:
                 if results and e.error_code == "NO_DATA_FOUND_IN_FILE":
                     # Expected when we try to read past the end of the file
                     return results
                 raise
             results.append((job_id, job_result))
-            if len(job_result["pages"]) < size:
+            if len(json_result["pages"]) < size:
                 break
             total += size
         return results

--- a/llama_parse/pyproject.toml
+++ b/llama_parse/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "llama-parse"
-version = "0.6.27"
+version = "0.6.28"
 description = "Parse files into RAG-Optimized formats."
 authors = ["Logan Markewich <logan@llamaindex.ai>"]
 license = "MIT"
@@ -13,7 +13,7 @@ packages = [{include = "llama_parse"}]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-llama-cloud-services = ">=0.6.27"
+llama-cloud-services = ">=0.6.28"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ python_version = "3.10"
 
 [tool.poetry]
 name = "llama-cloud-services"
-version = "0.6.27"
+version = "0.6.28"
 description = "Tailored SDK clients for LlamaCloud services."
 authors = ["Logan Markewich <logan@runllama.ai>"]
 license = "MIT"


### PR DESCRIPTION
Fixes `load_data` job result handling

- reverts this review change: https://github.com/run-llama/llama_cloud_services/pull/709/commits/0d6c3bf1fb60225809a0d2daedceb326275e77c3
- issue is that response schema changes depending on result type (ex. in JSON result, response data is paginated, markdown field is set as `md`. In `markdown` result, response data is not paginated, response field is set as `markdown`)

Will restore this in a follow up PR to handle it properly in the SDK (and only fetch result once), but for now this will fix CI and the released package