### PR TITLE
0.6.29: Standerdize the parsing input format for both .aget_json() and .aload_data()

### DIFF
--- a/llama_cloud_services/parse/base.py
+++ b/llama_cloud_services/parse/base.py
@@ -1396,7 +1396,7 @@ class LlamaParse(BasePydanticReader):
         extra_info: Optional[dict] = None,
     ) -> List[dict]:
         """Load data from the input path."""
-        if isinstance(file_path, (str, Path)):
+        if isinstance(file_path, (str, PurePosixPath, Path, bytes, BufferedIOBase)):
             return await self._aget_json(file_path, extra_info=extra_info)
         elif isinstance(file_path, list):
             jobs = [self._aget_json(f, extra_info=extra_info) for f in file_path]
@@ -1417,7 +1417,7 @@ class LlamaParse(BasePydanticReader):
                     raise e
         else:
             raise ValueError(
-                "The input file_path must be a string or a list of strings."
+                "The input file_path must be a string, Path, bytes, BufferedIOBase, or a list of these types."
             )
 
     def get_json_result(

--- a/llama_parse/pyproject.toml
+++ b/llama_parse/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "llama-parse"
-version = "0.6.28"
+version = "0.6.29"
 description = "Parse files into RAG-Optimized formats."
 authors = ["Logan Markewich <logan@llamaindex.ai>"]
 license = "MIT"
@@ -13,7 +13,7 @@ packages = [{include = "llama_parse"}]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-llama-cloud-services = ">=0.6.28"
+llama-cloud-services = ">=0.6.29"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ python_version = "3.10"
 
 [tool.poetry]
 name = "llama-cloud-services"
-version = "0.6.28"
+version = "0.6.29"
 description = "Tailored SDK clients for LlamaCloud services."
 authors = ["Logan Markewich <logan@runllama.ai>"]
 license = "MIT"


### PR DESCRIPTION
I am an external contributor from [Findr](https://www.usefindr.com/)

0.6.28: Standerdize the parsing input format for both .aget_json() and .aload_data()
* issue : https://github.com/run-llama/llama_cloud_services/issues/744
* parse: fix let .aget_json() take bytes as input as its .aload_data counter-part
![image](https://github.com/user-attachments/assets/7f226493-d84f-4876-ac71-a92c67ac53f9)


* This method is really important for Backends in general and right now we can only use .aget_json if we have the file physically stored in the directory

* bump to 0.6.29
