### PR TITLE
adding deprecation notice to llama-parse

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -43,17 +43,17 @@ jobs:
         run: |
           sleep 120
 
-      - name: Update llama-parse lock file
-        run: |
-          cd llama_parse && poetry lock
+      # - name: Update llama-parse lock file
+      #   run: |
+      #     cd llama_parse && poetry lock
 
-      - name: Build and publish llama-parse
-        uses: JRubics/poetry-publish@v2.1
-        with:
-          package_directory: "./llama_parse"
-          pypi_token: ${{ secrets.LLAMA_PARSE_PYPI_TOKEN }}
-          poetry_install_options: "--without dev"
-
+      # - name: Build and publish llama-parse
+      #   uses: JRubics/poetry-publish@v2.1
+      #   with:
+      #     package_directory: "./llama_parse"
+      #     pypi_token: ${{ secrets.LLAMA_PARSE_PYPI_TOKEN }}
+      #     poetry_install_options: "--without dev"
+      #
       - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1
@@ -64,7 +64,7 @@ jobs:
           release_name: ${{ github.ref }}
           draft: false
           prerelease: false
-
+      #
       - name: Get Asset name
         run: |
           export PKG=$(ls dist/ | grep tar)

--- a/llama_parse/README.md
+++ b/llama_parse/README.md
@@ -1,5 +1,8 @@
 # LlamaParse
 
+> [!CAUTION]
+> This project has been deprecated. Please use [llama-cloud-services](https://pypi.org/project/llama-cloud-services/) instead 
+
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/llama-parse)](https://pypi.org/project/llama-parse/)
 [![GitHub contributors](https://img.shields.io/github/contributors/run-llama/llama_parse)](https://github.com/run-llama/llama_parse/graphs/contributors)
 [![Discord](https://img.shields.io/discord/1059199217496772688)](https://discord.gg/dGcwcsnxhU)


### PR DESCRIPTION
We should use `llama-cloud-services` instead of `llama-parse`