### PR TITLE
feat: add table extraction for LlamaParse as CSV files

### DIFF
--- a/llama_cloud_services/parse/base.py
+++ b/llama_cloud_services/parse/base.py
@@ -3,7 +3,6 @@ import mimetypes
 import os
 import time
 import warnings
-import datetime
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from enum import Enum
@@ -38,8 +37,7 @@ from llama_cloud_services.parse.utils import (
     nest_asyncio_msg,
     make_api_request,
     partition_pages,
-    MarkdownTextAnalyzer,
-    md_table_to_pd_dataframe,
+    extract_tables_from_json_results,
 )
 
 # can put in a path to the file or the file bytes itself
@@ -1626,30 +1624,7 @@ class LlamaParse(BasePydanticReader):
     def get_tables(self, json_results: List[dict], download_path: str) -> List[str]:
         if not os.path.exists(download_path):
             os.makedirs(download_path)
-        tables = []
-        for json_result in json_results:
-            pages = json_result["pages"]
-            md_content: List[str] = []
-            for page in pages:
-                md_content.append(page["md"])
-            md_text = "\n\n---\n\n".join(md_content)
-            analyzer = MarkdownTextAnalyzer(text=md_text)
-            tables_dict = analyzer.identify_tables()
-            md_tables = tables_dict.get("Table", None)
-            if md_tables is None:
-                continue
-            else:
-                for md_table in md_tables:
-                    table = md_table_to_pd_dataframe(md_table=md_table)
-                    if table is not None:
-                        os.makedirs("data/extracted_tables/", exist_ok=True)
-                        save_path = f"{download_path}/table_{datetime.datetime.now().strftime('%Y_%d_%m_%H_%M_%S_%f')[:-3]}.csv"
-                        table.to_csv(
-                            save_path,
-                            index=False,
-                        )
-                        tables.append(save_path)
-        return tables
+        return extract_tables_from_json_results(json_results, download_path)
 
     async def aget_tables(
         self, json_result: List[dict], download_path: str

--- a/llama_cloud_services/parse/utils.py
+++ b/llama_cloud_services/parse/utils.py
@@ -1,8 +1,10 @@
 import httpx
 import itertools
 import logging
-import pandas as pd
+import os
 from enum import Enum
+from pathlib import Path
+from datetime import datetime
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -10,45 +12,13 @@ from tenacity import (
     retry_if_exception,
     before_sleep_log,
 )
-from typing import Any, Iterable, Iterator, Optional, Dict
-from typing_extensions import override
-from mrkdwn_analysis.markdown_analyzer import (
-    InlineParser,
-    MarkdownAnalyzer,
-    MarkdownParser,
-)
+from typing import Any, Iterable, Iterator, Optional, List, cast
 
 logger = logging.getLogger(__name__)
 
 # Asyncio error messages
 nest_asyncio_err = "cannot be called from a running event loop"
 nest_asyncio_msg = "The event loop is already running. Add `import nest_asyncio; nest_asyncio.apply()` to your code to fix this issue."
-
-
-class MarkdownTextAnalyzer(MarkdownAnalyzer):
-    @override
-    def __init__(self, text: str):
-        self.text = text
-        parser = MarkdownParser(self.text)
-        self.tokens = parser.parse()
-        self.references = parser.references
-        self.footnotes = parser.footnotes
-        self.inline_parser = InlineParser(
-            references=self.references, footnotes=self.footnotes
-        )
-        self._parse_inline_tokens()
-
-
-def md_table_to_pd_dataframe(md_table: Dict[str, list]) -> Optional[pd.DataFrame]:
-    try:
-        df = pd.DataFrame()
-        for i in range(len(md_table["header"])):
-            ls = [row[i] for row in md_table["rows"]]
-            df[md_table["header"][i]] = ls
-        return df
-    except Exception as e:
-        logger.error(f"Skipping table as an error occurred: {e}")
-        return None
 
 
 class ResultType(str, Enum):
@@ -384,3 +354,30 @@ def partition_pages(
             yield ",".join(targets)
         else:
             return
+
+
+def extract_tables_from_json_results(
+    json_results: List[dict], download_path: str
+) -> List[str]:
+    tables = []
+    for json_result in json_results:
+        pages = json_result["pages"]
+        for page in pages:
+            page = cast(dict, page)
+            items = page.get("items", [])
+            if items:
+                for i, item in enumerate(items):
+                    item = cast(dict, item)
+                    if item.get("type", "") == "table" and item.get("csv", ""):
+                        savepath = os.path.join(
+                            download_path,
+                            f"table_{datetime.now().strftime('%Y_%d_%m_%H_%M_%S_%f')[:-3]}.csv",
+                        )
+                        if Path(savepath).exists():
+                            savepath = (
+                                savepath.replace(".csv", "_")[0] + str(i) + ".csv"
+                            )
+                        with open(savepath, "w") as f:
+                            f.write(item["csv"])
+                        tables.append(savepath)
+    return tables

--- a/poetry.lock
+++ b/poetry.lock
@@ -391,7 +391,7 @@ version = "4.13.4"
 description = "Screen-scraping library"
 optional = false
 python-versions = ">=3.7.0"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b"},
     {file = "beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195"},
@@ -1979,40 +1979,6 @@ typing-inspect = ">=0.8.0"
 wrapt = "*"
 
 [[package]]
-name = "markdown-analysis"
-version = "0.1.5"
-description = ""
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "markdown_analysis-0.1.5-py3-none-any.whl", hash = "sha256:0b1058bf44d65f1d508bc53e46113631a98219fa040e6a3221d46d776b7728db"},
-    {file = "markdown_analysis-0.1.5.tar.gz", hash = "sha256:5a2091686011b38b9dd5617fae8e928b768288869fcf11d5f6d61186dc219657"},
-]
-
-[package.dependencies]
-beautifulsoup4 = "*"
-markdownify = "*"
-requests = "*"
-urllib3 = "*"
-
-[[package]]
-name = "markdownify"
-version = "1.1.0"
-description = "Convert HTML to markdown."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "markdownify-1.1.0-py3-none-any.whl", hash = "sha256:32a5a08e9af02c8a6528942224c91b933b4bd2c7d078f9012943776fc313eeef"},
-    {file = "markdownify-1.1.0.tar.gz", hash = "sha256:449c0bbbf1401c5112379619524f33b63490a8fa479456d41de9dc9e37560ebd"},
-]
-
-[package.dependencies]
-beautifulsoup4 = ">=4.9,<5"
-six = ">=1.15,<2"
-
-[[package]]
 name = "markupsafe"
 version = "3.0.2"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -2600,93 +2566,6 @@ files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
 ]
-
-[[package]]
-name = "pandas"
-version = "2.3.1"
-description = "Powerful data structures for data analysis, time series, and statistics"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "pandas-2.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:22c2e866f7209ebc3a8f08d75766566aae02bcc91d196935a1d9e59c7b990ac9"},
-    {file = "pandas-2.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3583d348546201aff730c8c47e49bc159833f971c2899d6097bce68b9112a4f1"},
-    {file = "pandas-2.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f951fbb702dacd390561e0ea45cdd8ecfa7fb56935eb3dd78e306c19104b9b0"},
-    {file = "pandas-2.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd05b72ec02ebfb993569b4931b2e16fbb4d6ad6ce80224a3ee838387d83a191"},
-    {file = "pandas-2.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1b916a627919a247d865aed068eb65eb91a344b13f5b57ab9f610b7716c92de1"},
-    {file = "pandas-2.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fe67dc676818c186d5a3d5425250e40f179c2a89145df477dd82945eaea89e97"},
-    {file = "pandas-2.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:2eb789ae0274672acbd3c575b0598d213345660120a257b47b5dafdc618aec83"},
-    {file = "pandas-2.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2b0540963d83431f5ce8870ea02a7430adca100cec8a050f0811f8e31035541b"},
-    {file = "pandas-2.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fe7317f578c6a153912bd2292f02e40c1d8f253e93c599e82620c7f69755c74f"},
-    {file = "pandas-2.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6723a27ad7b244c0c79d8e7007092d7c8f0f11305770e2f4cd778b3ad5f9f85"},
-    {file = "pandas-2.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3462c3735fe19f2638f2c3a40bd94ec2dc5ba13abbb032dd2fa1f540a075509d"},
-    {file = "pandas-2.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:98bcc8b5bf7afed22cc753a28bc4d9e26e078e777066bc53fac7904ddef9a678"},
-    {file = "pandas-2.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4d544806b485ddf29e52d75b1f559142514e60ef58a832f74fb38e48d757b299"},
-    {file = "pandas-2.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:b3cd4273d3cb3707b6fffd217204c52ed92859533e31dc03b7c5008aa933aaab"},
-    {file = "pandas-2.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:689968e841136f9e542020698ee1c4fbe9caa2ed2213ae2388dc7b81721510d3"},
-    {file = "pandas-2.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:025e92411c16cbe5bb2a4abc99732a6b132f439b8aab23a59fa593eb00704232"},
-    {file = "pandas-2.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b7ff55f31c4fcb3e316e8f7fa194566b286d6ac430afec0d461163312c5841e"},
-    {file = "pandas-2.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7dcb79bf373a47d2a40cf7232928eb7540155abbc460925c2c96d2d30b006eb4"},
-    {file = "pandas-2.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:56a342b231e8862c96bdb6ab97170e203ce511f4d0429589c8ede1ee8ece48b8"},
-    {file = "pandas-2.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ca7ed14832bce68baef331f4d7f294411bed8efd032f8109d690df45e00c4679"},
-    {file = "pandas-2.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ac942bfd0aca577bef61f2bc8da8147c4ef6879965ef883d8e8d5d2dc3e744b8"},
-    {file = "pandas-2.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9026bd4a80108fac2239294a15ef9003c4ee191a0f64b90f170b40cfb7cf2d22"},
-    {file = "pandas-2.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6de8547d4fdb12421e2d047a2c446c623ff4c11f47fddb6b9169eb98ffba485a"},
-    {file = "pandas-2.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:782647ddc63c83133b2506912cc6b108140a38a37292102aaa19c81c83db2928"},
-    {file = "pandas-2.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ba6aff74075311fc88504b1db890187a3cd0f887a5b10f5525f8e2ef55bfdb9"},
-    {file = "pandas-2.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e5635178b387bd2ba4ac040f82bc2ef6e6b500483975c4ebacd34bec945fda12"},
-    {file = "pandas-2.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f3bf5ec947526106399a9e1d26d40ee2b259c66422efdf4de63c848492d91bb"},
-    {file = "pandas-2.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:1c78cf43c8fde236342a1cb2c34bcff89564a7bfed7e474ed2fffa6aed03a956"},
-    {file = "pandas-2.3.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8dfc17328e8da77be3cf9f47509e5637ba8f137148ed0e9b5241e1baf526e20a"},
-    {file = "pandas-2.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ec6c851509364c59a5344458ab935e6451b31b818be467eb24b0fe89bd05b6b9"},
-    {file = "pandas-2.3.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:911580460fc4884d9b05254b38a6bfadddfcc6aaef856fb5859e7ca202e45275"},
-    {file = "pandas-2.3.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f4d6feeba91744872a600e6edbbd5b033005b431d5ae8379abee5bcfa479fab"},
-    {file = "pandas-2.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fe37e757f462d31a9cd7580236a82f353f5713a80e059a29753cf938c6775d96"},
-    {file = "pandas-2.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5db9637dbc24b631ff3707269ae4559bce4b7fd75c1c4d7e13f40edc42df4444"},
-    {file = "pandas-2.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4645f770f98d656f11c69e81aeb21c6fca076a44bed3dcbb9396a4311bc7f6d8"},
-    {file = "pandas-2.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:342e59589cc454aaff7484d75b816a433350b3d7964d7847327edda4d532a2e3"},
-    {file = "pandas-2.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d12f618d80379fde6af007f65f0c25bd3e40251dbd1636480dfffce2cf1e6da"},
-    {file = "pandas-2.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd71c47a911da120d72ef173aeac0bf5241423f9bfea57320110a978457e069e"},
-    {file = "pandas-2.3.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:09e3b1587f0f3b0913e21e8b32c3119174551deb4a4eba4a89bc7377947977e7"},
-    {file = "pandas-2.3.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2323294c73ed50f612f67e2bf3ae45aea04dce5690778e08a09391897f35ff88"},
-    {file = "pandas-2.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:b4b0de34dc8499c2db34000ef8baad684cfa4cbd836ecee05f323ebfba348c7d"},
-    {file = "pandas-2.3.1.tar.gz", hash = "sha256:0a95b9ac964fe83ce317827f80304d37388ea77616b1425f0ae41c9d2d0d7bb2"},
-]
-
-[package.dependencies]
-numpy = [
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
-]
-python-dateutil = ">=2.8.2"
-pytz = ">=2020.1"
-tzdata = ">=2022.7"
-
-[package.extras]
-all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)", "beautifulsoup4 (>=4.11.2)", "bottleneck (>=1.3.6)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=2022.12.0)", "fsspec (>=2022.11.0)", "gcsfs (>=2022.11.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.9.2)", "matplotlib (>=3.6.3)", "numba (>=0.56.4)", "numexpr (>=2.8.4)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "pandas-gbq (>=0.19.0)", "psycopg2 (>=2.9.6)", "pyarrow (>=10.0.1)", "pymysql (>=1.0.2)", "pyreadstat (>=1.2.0)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "qtpy (>=2.3.0)", "s3fs (>=2022.11.0)", "scipy (>=1.10.0)", "tables (>=3.8.0)", "tabulate (>=0.9.0)", "xarray (>=2022.12.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)", "zstandard (>=0.19.0)"]
-aws = ["s3fs (>=2022.11.0)"]
-clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.3.0)"]
-compression = ["zstandard (>=0.19.0)"]
-computation = ["scipy (>=1.10.0)", "xarray (>=2022.12.0)"]
-consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
-excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)"]
-feather = ["pyarrow (>=10.0.1)"]
-fss = ["fsspec (>=2022.11.0)"]
-gcp = ["gcsfs (>=2022.11.0)", "pandas-gbq (>=0.19.0)"]
-hdf5 = ["tables (>=3.8.0)"]
-html = ["beautifulsoup4 (>=4.11.2)", "html5lib (>=1.1)", "lxml (>=4.9.2)"]
-mysql = ["SQLAlchemy (>=2.0.0)", "pymysql (>=1.0.2)"]
-output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.9.0)"]
-parquet = ["pyarrow (>=10.0.1)"]
-performance = ["bottleneck (>=1.3.6)", "numba (>=0.56.4)", "numexpr (>=2.8.4)"]
-plot = ["matplotlib (>=3.6.3)"]
-postgresql = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "psycopg2 (>=2.9.6)"]
-pyarrow = ["pyarrow (>=10.0.1)"]
-spss = ["pyreadstat (>=1.2.0)"]
-sql-other = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)"]
-test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
-xml = ["lxml (>=4.9.2)"]
 
 [[package]]
 name = "pandocfilters"
@@ -3284,7 +3163,7 @@ version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -3325,18 +3204,6 @@ typing_extensions = {version = "*", markers = "python_version < \"3.10\""}
 
 [package.extras]
 dev = ["backports.zoneinfo ; python_version < \"3.9\"", "black", "build", "freezegun", "mdx_truly_sane_lists", "mike", "mkdocs", "mkdocs-awesome-pages-plugin", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-material (>=8.5)", "mkdocstrings[python]", "msgspec ; implementation_name != \"pypy\"", "mypy", "orjson ; implementation_name != \"pypy\"", "pylint", "pytest", "tzdata", "validate-pyproject[all]"]
-
-[[package]]
-name = "pytz"
-version = "2025.2"
-description = "World timezone definitions, modern and historical"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
-    {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
-]
 
 [[package]]
 name = "pywin32"
@@ -3997,7 +3864,7 @@ version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -4021,7 +3888,7 @@ version = "2.7"
 description = "A modern CSS selector implementation for Beautiful Soup."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4"},
     {file = "soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a"},
@@ -4406,18 +4273,6 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
-name = "tzdata"
-version = "2025.2"
-description = "Provider of IANA time zone data"
-optional = false
-python-versions = ">=2"
-groups = ["main"]
-files = [
-    {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
-    {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
-]
-
-[[package]]
 name = "uri-template"
 version = "1.3.0"
 description = "RFC 6570 URI Template Processor"
@@ -4768,4 +4623,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "e466c26ce68bc093cccc280319a16288f1fcad6f98baacb816f4739d52f41360"
+content-hash = "487717a0bbe7ff67360e3e9f187e15a33c77e4942a7c909cb37b95425a81544c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ packages = [{include = "llama_cloud_services"}]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-pandas = ">=2.3.1"
-markdown-analysis = ">=0.1.5"
 llama-index-core = ">=0.12.0"
 llama-cloud = "==0.1.33"
 pydantic = ">=2.8,!=2.10"

--- a/tests/parse/test_utils.py
+++ b/tests/parse/test_utils.py
@@ -1,84 +1,30 @@
 import pytest
-import pandas as pd
 
+from pathlib import Path
 from llama_cloud_services.parse.utils import (
     expand_target_pages,
     partition_pages,
-    MarkdownTextAnalyzer,
-    md_table_to_pd_dataframe,
+    extract_tables_from_json_results,
 )
+from typing import List
 
 
 @pytest.fixture()
-def dataframe_from_tables() -> pd.DataFrame:
-    project_data = {
-        "Project Name": [
-            "User Dashboard",
-            "API Integration",
-            "Mobile App",
-            "Database Migration",
-            "Security Audit",
-        ],
-        "Status": [
-            "In Progress",
-            "Completed",
-            "Planning",
-            "In Progress",
-            "Not Started",
-        ],
-        "Completion %": ["75%", "100%", "25%", "60%", "0%"],
-        "Assigned Developer": [
-            "Alice Johnson",
-            "Bob Smith",
-            "Carol Davis",
-            "David Wilson",
-            "Eve Brown",
-        ],
-        "Due Date": [
-            "2025-07-15",
-            "2025-06-30",
-            "2025-08-20",
-            "2025-07-10",
-            "2025-08-01",
-        ],
-    }
-
-    df = pd.DataFrame(project_data)
-    return df
-
-
-@pytest.fixture()
-def markdown_file_text() -> str:
-    return """
-## Team Performance Metrics
-
-The table below shows our team's performance across different projects:
-
-| Project Name       | Status      | Completion % | Assigned Developer | Due Date   |
-| ------------------ | ----------- | ------------ | ------------------ | ---------- |
-| User Dashboard     | In Progress | 75%          | Alice Johnson      | 2025-07-15 |
-| API Integration    | Completed   | 100%         | Bob Smith          | 2025-06-30 |
-| Mobile App         | Planning    | 25%          | Carol Davis        | 2025-08-20 |
-| Database Migration | In Progress | 60%          | David Wilson       | 2025-07-10 |
-| Security Audit     | Not Started | 0%           | Eve Brown          | 2025-08-01 |
-
-| Project Name       | Status      | Completion % | Assigned Developer | Due Date   |
-| ------------------ | ----------- | ------------ | ------------------ | ---------- |
-| User Dashboard     | In Progress | 75%          | Alice Johnson      | 2025-07-15 |
-| API Integration    | Completed   | 100%         | Bob Smith          | 2025-06-30 |
-| Mobile App         | Planning    | 25%          | Carol Davis        | 2025-08-20 |
-| Database Migration | In Progress | 60%          | David Wilson       | 2025-07-10 |
-| Security Audit     | Not Started | 0%           | Eve Brown          | 2025-08-01 |
-
-## Key Observations
-
-Based on the data above, we can see that:
-
-- The API Integration project was completed on schedule
-- The User Dashboard is progressing well and should meet its deadline
-- The Database Migration needs attention to stay on track
-- We need to begin the Security Audit soon to meet the August deadline
-"""
+def pseudo_json_results() -> List[dict]:
+    return [
+        {
+            "pages": [
+                {
+                    "items": [
+                        {
+                            "type": "table",
+                            "csv": "Name,Age,Height (cm)\nAnna,12,140\nBob,22,175\nClaire,33,173\nDenis,44,185\n",
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 
 
 def test_expand_target_pages() -> None:
@@ -107,13 +53,10 @@ def test_partion_pages() -> None:
     assert result == ["0,2-3", "5,8-9", "10"]
 
 
-def test_table_to_dataframe(
-    markdown_file_text: str, dataframe_from_tables: pd.DataFrame
-) -> None:
-    analyzer = MarkdownTextAnalyzer(markdown_file_text)
-    md_tables = analyzer.identify_tables()["Table"]
-    assert len(md_tables) == 2
-    for md_table in md_tables:
-        df = md_table_to_pd_dataframe(md_table)
-        assert df is not None
-        assert df.equals(dataframe_from_tables)
+def test_table_extraction(pseudo_json_results: List[dict], tmpdir: Path) -> None:
+    tables = extract_tables_from_json_results(pseudo_json_results, tmpdir)
+    assert len(tables) == 1
+    for table in tables:
+        assert Path(table).exists()
+        with open(table) as t:
+            assert t.read() == pseudo_json_results[0]["pages"][0]["items"][0]["csv"]


### PR DESCRIPTION
Combining [`markdown-analysis`](https://pypi.org/project/markdown-analysis/) and `pandas`, we add the possibility for users to directly get their tables from LlamaParse JSON results. 

The idea is:

```python
parser = LlamaParse(api_key="llx-***", result_type="markdown")
result = parser.get_json_result("path/to/file")
tables = parser.get_tables(json_result=result, download_path="tables/")
```

This will save the tables in the markdown text as CSV files in the `tables` folder.