### PR TITLE
parse: expose functionality to get raw job results

### DIFF
--- a/llama_cloud_services/parse/types.py
+++ b/llama_cloud_services/parse/types.py
@@ -303,27 +303,55 @@ class JobResult(BaseModel):
 
     def get_markdown(self) -> str:
         """
-        Get the parsed markdown from the job, distinct from the markdown documents.
+        Get the raw parsed markdown from the job, distinct from the markdown documents.
         This does not include page separators, e.g. if merge_tables_across_pages_in_markdown is True
         """
         return asyncio_run(self.aget_markdown())
 
     async def aget_markdown(self) -> str:
         """
-        Get the parsed markdown from the job, distinct from the markdown documents.
+        Get the raw parsed markdown from the job, distinct from the markdown documents.
         This does not include page separators, e.g. if merge_tables_across_pages_in_markdown is True
         """
-        from llama_cloud.client import AsyncLlamaCloud
+        url = f"{self._base_url}/api/v1/parsing/job/{self.job_id}/result/raw/markdown"
+        response = await make_api_request(self._client, "GET", url)
+        return response.content.decode("utf-8")
 
-        client = AsyncLlamaCloud(
-            base_url=self._base_url,
-            token=self._api_key,
-            httpx_client=self._client,
-        )
-        result = await client.parsing.get_job_result(
-            job_id=self.job_id,
-        )
-        return result.markdown
+    def get_text(self) -> str:
+        """
+        Get the raw parsed text from the job.
+        """
+        return asyncio_run(self.aget_text())
+
+    async def aget_text(self) -> str:
+        """
+        Get the raw parsed text from the job.
+        """
+        url = f"{self._base_url}/api/v1/parsing/job/{self.job_id}/result/raw/text"
+        response = await make_api_request(self._client, "GET", url)
+        return response.content.decode("utf-8")
+
+    def get_json(self) -> Dict[str, Any]:
+        """
+        Get the full parsed JSON result from the job.
+
+        Note:
+            This is not the same as JobResult.json(), which is a
+            JSON serialized version of the JobResult Page Documents.
+        """
+        return asyncio_run(self.aget_json())
+
+    async def aget_json(self) -> Dict[str, Any]:
+        """
+        Get the full parsed JSON result from the job.
+
+        Note:
+            This is not the same as JobResult.json(), which is a
+            JSON serialized version of the JobResult Page Documents.
+        """
+        url = f"{self._base_url}/api/v1/parsing/job/{self.job_id}/result/json"
+        response = await make_api_request(self._client, "GET", url)
+        return response.json()
 
     async def _get_image_document_with_bytes(
         self, image: ImageItem, page: Page

--- a/tests/parse/test_llama_parse.py
+++ b/tests/parse/test_llama_parse.py
@@ -193,3 +193,12 @@ async def test_multiple_page_markdown(
     result = await markdown_parser.aload_data(filepath)
     assert len(result) == expected
     assert all(len(doc.text) > 0 for doc in result)
+
+
+@pytest.mark.asyncio
+async def test_get_result(markdown_parser: LlamaParse) -> None:
+    filepath = "tests/test_files/attention_is_all_you_need.pdf"
+    expected = await markdown_parser.aparse(filepath)
+    result = await markdown_parser.aget_result(expected.job_id)
+    assert result.job_id == expected.job_id
+    assert len(result.pages) == len(expected.pages)

--- a/tests/parse/test_llama_parse_result.py
+++ b/tests/parse/test_llama_parse_result.py
@@ -83,6 +83,12 @@ async def test_basic_parse_result(file_path: str, partition_pages: Optional[int]
     assert image_documents[0].image is not None
     assert len(image_documents[0].resolve_image().getvalue()) > 0
 
+    assert len(await result.aget_text()) > 0
+    assert len(await result.aget_markdown()) > 0
+    json = await result.aget_json()
+    assert json.get("job_metadata")
+    assert len(json.get("pages", [])) == len(result.pages)
+
 
 @pytest.mark.asyncio
 @pytest.mark.skip(


### PR DESCRIPTION
- Adds `LlamaParse.aget_result(job_id)` to use parser to retrieve already parsed JobResults
- Adds `JobResult.aget_text()`, `JobResult.aget_json()`, updates `JobResult.aget_markdown()` equivalents to the raw API result calls (and associated `get_...` sync versions) 
    - needed since the raw parse result is not always the same as the paginated LlamaIndex `Page/Document` objects

Closes #800 (no longer needed)