### PR TITLE
fix: no git checks on pnpm publish

### DIFF
--- a/.github/workflows/release_ts.yml
+++ b/.github/workflows/release_ts.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --access public
+        run: pnpm publish --access public --no-git-checks
 
       - name: Create release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
As per title (otherwise the publish action fails)