### PR TITLE
parse: expose HTML output for result table items when possible

### DIFF
--- a/py/llama_cloud_services/parse/types.py
+++ b/py/llama_cloud_services/parse/types.py
@@ -52,6 +52,10 @@ class PageItem(BaseModel):
     bBox: Optional[BBox] = Field(
         default=None, description="The bounding box of the item."
     )
+    html: Optional[str] = Field(
+        default=None,
+        description="The HTML-formatted content of the item. Only applicable for table items when output_tables_as_HTML=True.",
+    )
 
 
 class ImageItem(BaseModel):


### PR DESCRIPTION
- Expose `PageItem.html` when possible (when `output_tables_as_HTML` is set, both the `html` and `md` will be available in the parse JSON result for table items)

Closes https://github.com/run-llama/llama_index/issues/19602