### PR TITLE
chore: bump ts version for parse

### DIFF
--- a/ts/llama_cloud_services/package.json
+++ b/ts/llama_cloud_services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llama-cloud-services",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
As per title, so now we can release llama-cloud-services with the refactored `parse` methods