### PR TITLE
feat: export ExtractedFieldMetadata and ExtractedFieldMetadataDict types

### DIFF
--- a/ts/llama_cloud_services/package.json
+++ b/ts/llama_cloud_services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llama-cloud-services",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/ts/llama_cloud_services/src/beta/agent/index.ts
+++ b/ts/llama_cloud_services/src/beta/agent/index.ts
@@ -4,6 +4,8 @@ export type {
   AggregateAgentDataOptions,
   ComparisonOperator,
   ExtractedData,
+  ExtractedFieldMetadata,
+  ExtractedFieldMetadataDict,
   FilterOperation,
   SearchAgentDataOptions,
   StatusType,

--- a/ts/llama_cloud_services/src/reader.ts
+++ b/ts/llama_cloud_services/src/reader.ts
@@ -194,7 +194,7 @@ export class LlamaParseReader extends FileReader {
       ? this.language
       : [this.language];
     this.stdout =
-      params.stdout ?? typeof process !== "undefined"
+      (params.stdout ?? typeof process !== "undefined")
         ? process!.stdout
         : undefined;
     const apiKey = params.apiKey ?? getEnv("LLAMA_CLOUD_API_KEY");

--- a/ts/llama_cloud_services/src/reader.ts
+++ b/ts/llama_cloud_services/src/reader.ts
@@ -194,7 +194,7 @@ export class LlamaParseReader extends FileReader {
       ? this.language
       : [this.language];
     this.stdout =
-      (params.stdout ?? typeof process !== "undefined")
+      params.stdout ?? typeof process !== "undefined"
         ? process!.stdout
         : undefined;
     const apiKey = params.apiKey ?? getEnv("LLAMA_CLOUD_API_KEY");


### PR DESCRIPTION
Add missing type exports for ExtractedFieldMetadata and ExtractedFieldMetadataDict from beta/agent module. These types were defined but not exported, making them inaccessible to external consumers.