### PR TITLE
fix: Make env based api url overrideable

### DIFF
--- a/py/llama_parse/pyproject.toml
+++ b/py/llama_parse/pyproject.toml
@@ -11,13 +11,13 @@ dev = [
 
 [project]
 name = "llama-parse"
-version = "0.6.60"
+version = "0.6.62"
 description = "Parse files into RAG-Optimized formats."
 authors = [{name = "Logan Markewich", email = "logan@llamaindex.ai"}]
 requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"
-dependencies = ["llama-cloud-services>=0.6.60"]
+dependencies = ["llama-cloud-services>=0.6.62"]
 
 [project.scripts]
 llama-parse = "llama_parse.cli.main:parse"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
 
 [project]
 name = "llama-cloud-services"
-version = "0.6.61"
+version = "0.6.62"
 description = "Tailored SDK clients for LlamaCloud services."
 authors = [{name = "Logan Markewich", email = "logan@runllama.ai"}]
 requires-python = ">=3.9,<4.0"

--- a/py/unit_tests/parse/test_base.py
+++ b/py/unit_tests/parse/test_base.py
@@ -1,0 +1,57 @@
+from collections.abc import Generator
+import pytest
+import os
+
+from llama_cloud_services.parse.base import LlamaParse
+
+
+@pytest.fixture(autouse=True)
+def clear_env() -> Generator[None, None, None]:
+    """entirely clear the environment, and then reset after test completion"""
+    original_env = os.environ.copy()
+    os.environ.clear()
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)
+
+
+def test_should_obtain_api_key_base_url_from_env_vars():
+    os.environ["LLAMA_CLOUD_API_KEY"] = "test-api-key"
+    os.environ["LLAMA_CLOUD_BASE_URL"] = "https://example.test"
+
+    client = LlamaParse()
+    assert client.api_key == "test-api-key"
+    assert client.base_url == "https://example.test"
+
+
+def test_should_be_able_to_pass_api_key_base_url_as_kwargs():
+    os.environ["LLAMA_CLOUD_API_KEY"] = "not-this-one"
+    os.environ["LLAMA_CLOUD_BASE_URL"] = "https://wrong.site"
+
+    client = LlamaParse(
+        api_key="test-api-key",
+        base_url="https://example.test",
+    )
+    assert client.api_key == "test-api-key"
+    assert client.base_url == "https://example.test"
+
+
+def test_should_raise_error_if_api_key_is_not_provided():
+    with pytest.raises(ValueError, match="The API key is required."):
+        LlamaParse()
+
+
+def test_should_default_to_llama_cloud_base_url_if_not_provided():
+    client = LlamaParse(
+        api_key="test-api-key",
+    )
+    assert client.base_url == "https://api.cloud.llamaindex.ai"
+
+
+def test_json_parseable():
+    os.environ["LLAMA_CLOUD_API_KEY"] = "test-api-key"
+    client2 = LlamaParse.model_validate_json('{"base_url":"https://example.test"}')
+    assert client2.api_key == "test-api-key"
+    assert client2.base_url == "https://example.test"


### PR DESCRIPTION
Currently if you have an env var for base api url, you cannot explicitly override it. This modifies the process to use a factor default rather than the validator as it makes things a bit more simple (I think the code was reading from the env var first due to the the `default=DEFAULT_BASE_URL` being set to the `v` value, so without the env var precedence, the env var would never be used)