### PR TITLE
parse: expose page.slideSpeakerNotes

### DIFF
--- a/py/llama_cloud_services/parse/types.py
+++ b/py/llama_cloud_services/parse/types.py
@@ -159,6 +159,9 @@ class Page(BaseModel):
     durationInSeconds: Optional[float] = Field(
         default=None, description="The duration of the audio transcript in seconds."
     )
+    slideSpeakerNotes: Optional[str] = Field(
+        default=None, description="The speaker notes for the slide."
+    )
 
 
 class JobResult(BaseModel):


### PR DESCRIPTION
Exposes `page.slideSpeakerNotes` in JobResult