### PR TITLE
Added "SourceText" to __init__.py

### DIFF
--- a/py/llama_cloud_services/__init__.py
+++ b/py/llama_cloud_services/__init__.py
@@ -1,6 +1,6 @@
 from llama_cloud_services.parse import LlamaParse
 from llama_cloud_services.report import ReportClient, LlamaReport
-from llama_cloud_services.extract import LlamaExtract, ExtractionAgent
+from llama_cloud_services.extract import LlamaExtract, ExtractionAgent, SourceText
 from llama_cloud_services.constants import EU_BASE_URL
 from llama_cloud_services.index import (
     LlamaCloudCompositeRetriever,
@@ -14,6 +14,7 @@ __all__ = [
     "LlamaReport",
     "LlamaExtract",
     "ExtractionAgent",
+    "SourceText",
     "EU_BASE_URL",
     "LlamaCloudIndex",
     "LlamaCloudRetriever",


### PR DESCRIPTION
Added `SourceText` to `__init__.py`, in order for the method to be available for imports in the cases we would like to directly provide the text to be used for information extraction, as also mentioned in the [documentation](https://docs.cloud.llamaindex.ai/llamaextract/getting_started/python).