### PR TITLE
client unification

### DIFF
--- a/ts/llama_cloud_services/package.json
+++ b/ts/llama_cloud_services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llama-cloud-services",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/ts/llama_cloud_services/src/beta/agent/client.ts
+++ b/ts/llama_cloud_services/src/beta/agent/client.ts
@@ -1,5 +1,5 @@
-import { createClient, createConfig } from "@hey-api/client-fetch";
-import { getEnv } from "@llamaindex/env";
+import { createClient } from "@hey-api/client-fetch";
+import { client as defaultClient } from "../../api";
 import {
   aggregateAgentDataApiV1BetaAgentDataAggregatePost,
   createAgentDataApiV1BetaAgentDataPost,
@@ -24,36 +24,19 @@ import type {
  */
 export class AgentClient<T = unknown> {
   private client: ReturnType<typeof createClient>;
-  private baseUrl: string;
-  private headers: Record<string, string>;
   private collection: string;
   private agentUrlId: string;
 
   constructor({
-    apiKey = getEnv("LLAMA_CLOUD_API_KEY"),
-    baseUrl = "https://api.cloud.llamaindex.ai/",
+    client = defaultClient,
     collection = "default",
     agentUrlId = "_public",
   }: {
-    apiKey?: string;
-    baseUrl?: string;
+    client?: ReturnType<typeof createClient>;
     collection?: string;
     agentUrlId?: string;
   }) {
-    this.baseUrl = baseUrl;
-
-    this.headers = {
-      "X-SDK-Name": "llamaindex-ts",
-      ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
-    };
-
-    this.client = createClient(
-      createConfig({
-        baseUrl: this.baseUrl,
-        headers: this.headers,
-      }),
-    );
-
+    this.client = client;
     this.collection = collection;
     this.agentUrlId = agentUrlId;
   }
@@ -281,15 +264,13 @@ export interface AgentDataClientOptions {
  * @returns A new AgentClient instance
  */
 export function createAgentDataClient<T = unknown>({
-  apiKey,
-  baseUrl,
+  client = defaultClient,
   windowUrl,
   env,
   agentUrlId,
   collection = "default",
 }: {
-  apiKey?: string;
-  baseUrl?: string;
+  client?: ReturnType<typeof createClient>;
   windowUrl?: string;
   env?: Record<string, string>;
   agentUrlId?: string;
@@ -321,9 +302,8 @@ export function createAgentDataClient<T = unknown>({
   }
 
   return new AgentClient({
-    ...(apiKey && { apiKey }),
-    ...(baseUrl && { baseUrl }),
     ...(agentUrlId && { agentUrlId }),
     collection,
+    client,
   });
 }

--- a/ts/llama_cloud_services/tests/client.test.ts
+++ b/ts/llama_cloud_services/tests/client.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { listProjectsApiV1ProjectsGet, client } from "../src/api.js";
+
+describe("Global client configuration", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("adds X-SDK-Name header from global client config", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        // Validate the header is present on the outgoing request
+        let headers: Headers;
+        if (input && typeof input === "object" && "headers" in (input as any)) {
+          headers = (input as Request).headers;
+        } else {
+          headers = new Headers((init && init.headers) || {});
+        }
+        expect(headers.get("X-SDK-Name")).toBe("llamaindex-ts");
+
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+    // Trigger any request via the generated SDK (imported through src/api.ts)
+    await listProjectsApiV1ProjectsGet({ throwOnError: false });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("respects additional custom headers set via setConfig", async () => {
+    const prevConfig = client.getConfig();
+    try {
+      client.setConfig({
+        ...prevConfig,
+        headers: {
+          ...(prevConfig.headers || {}),
+          "X-Custom-Header": "custom-value",
+        },
+      });
+
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input, init) => {
+          let headers: Headers;
+          if (
+            input &&
+            typeof input === "object" &&
+            "headers" in (input as any)
+          ) {
+            headers = (input as Request).headers;
+          } else {
+            headers = new Headers((init && init.headers) || {});
+          }
+          expect(headers.get("X-SDK-Name")).toBe("llamaindex-ts");
+          expect(headers.get("X-Custom-Header")).toBe("custom-value");
+
+          return new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        });
+
+      await listProjectsApiV1ProjectsGet({ throwOnError: false });
+      expect(fetchSpy).toHaveBeenCalledOnce();
+    } finally {
+      // Restore original configuration to avoid test cross-talk
+      client.setConfig(prevConfig);
+    }
+  });
+});


### PR DESCRIPTION
For some reason Agent Data was creating its own client, causing lots of extra configuration overhead. This simplifies it to just use the standard library client.