### PR TITLE
fix: make ts release beautiful again

### DIFF
--- a/.github/workflows/release_ts.yml
+++ b/.github/workflows/release_ts.yml
@@ -47,6 +47,6 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: "ts/llama_cloud_services/llama-cloud-services*.tgz"
-          name: Release ${{ github.ref }} - LlamaCloud Services TS
-          bodyFile: "ts/llama_cloud_services/CHANGELOG.md"
+          name: Release ${{ github.ref_name }} - LlamaCloud Services TS
+          generateReleaseNotes: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With this PR, we make the release notes for TS releases aligned with those for PY release, removing `refs/tag/` from the title and generating actual release notes without relying on an outdated changelog.
