### PR TITLE
Refactor agent fields in llama_cloud_services

### DIFF
--- a/py/llama_cloud_services/beta/agent_data/client.py
+++ b/py/llama_cloud_services/beta/agent_data/client.py
@@ -86,7 +86,7 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
             client=llama_client,
             type=ExtractedPerson,
             collection="extracted_people",
-            agent_url_id="person-extraction-agent"
+            deployment_name="person-extraction-agent"
         )
 
         # Create data
@@ -109,7 +109,7 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
         self,
         type: Type[AgentDataT],
         collection: str = "default",
-        agent_url_id: Optional[str] = None,
+        deployment_name: Optional[str] = None,
         client: Optional[AsyncLlamaCloud] = None,
         token: Optional[str] = None,
         base_url: Optional[str] = None,
@@ -123,11 +123,11 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
             collection: Named collection within the agent for organizing data.
                 Defaults to "default". Collections allow logical separation of
                 different data types or workflows within the same agent.
-            agent_url_id: Unique identifier for the agent. This normally appears in the
-                url of an agent within the llama cloud platform. If not provided,
-                will attempt to use the LLAMA_DEPLOY_DEPLOYMENT_NAME environment
-                variable. Data can only be added to an already existing agent in the
-                platform.
+            deployment_name: Unique identifier for the agent deployment. This normally
+                appears in the URL of an agent within the Llama Cloud platform. If not
+                provided, will attempt to use the LLAMA_DEPLOY_DEPLOYMENT_NAME
+                environment variable. Data can only be added to an already existing
+                agent in the platform.
             client: AsyncLlamaCloud client instance for API communication. If not provided, will
                 construct one from the provided api token and base url
             token: Llama Cloud API token. Reads from LLAMA_CLOUD_API_KEY if not provided
@@ -135,15 +135,14 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
                 defaults to https://api.cloud.llamaindex.ai
 
         Raises:
-            ValueError: If agent_url_id is not provided and the
+            ValueError: If deployment_name is not provided and the
                 LLAMA_DEPLOY_DEPLOYMENT_NAME environment variable is not set
 
         Note:
             The client automatically applies retry logic to all API calls with
             exponential backoff for timeout, connection, and HTTP status errors.
         """
-
-        self.agent_url_id = agent_url_id or get_default_agent_id()
+        self.deployment_name = deployment_name or get_default_agent_id()
 
         self.collection = collection
         if not client:
@@ -164,7 +163,7 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
     @agent_data_retry
     async def create_item(self, data: AgentDataT) -> TypedAgentData[AgentDataT]:
         raw_data = await self.client.beta.create_agent_data(
-            agent_slug=self.agent_url_id,
+            deployment_name=self.deployment_name,
             collection=self.collection,
             data=data.model_dump(),
         )
@@ -211,7 +210,7 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
             include_total: Whether to include the total count in the response. Defaults to False to improve performance. It's recommended to only request on the first page.
         """
         raw = await self.client.beta.search_agent_data_api_v_1_beta_agent_data_search_post(
-            agent_slug=self.agent_url_id,
+            deployment_name=self.deployment_name,
             collection=self.collection,
             filter=filter,
             order_by=order_by,
@@ -254,7 +253,7 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
             page_size: Maximum number of groups to return per page.
         """
         raw = await self.client.beta.aggregate_agent_data_api_v_1_beta_agent_data_aggregate_post(
-            agent_slug=self.agent_url_id,
+            deployment_name=self.deployment_name,
             collection=self.collection,
             page_size=page_size,
             filter=filter,

--- a/py/llama_cloud_services/beta/agent_data/client.py
+++ b/py/llama_cloud_services/beta/agent_data/client.py
@@ -113,6 +113,8 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
         client: Optional[AsyncLlamaCloud] = None,
         token: Optional[str] = None,
         base_url: Optional[str] = None,
+        # deprecated, use deployment_name instead
+        agent_url_id: Optional[str] = None,
     ):
         """
         Initialize the AsyncAgentDataClient.
@@ -142,7 +144,7 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
             The client automatically applies retry logic to all API calls with
             exponential backoff for timeout, connection, and HTTP status errors.
         """
-        self.deployment_name = deployment_name or get_default_agent_id()
+        self.deployment_name = deployment_name or agent_url_id or get_default_agent_id()
 
         self.collection = collection
         if not client:

--- a/py/llama_cloud_services/beta/agent_data/schema.py
+++ b/py/llama_cloud_services/beta/agent_data/schema.py
@@ -10,7 +10,7 @@ CRUD operations, search capabilities, filtering, and aggregation functionality
 for managing agent-generated data at scale.
 
 Key Concepts:
-- Agent Slug: Unique identifier for an agent instance
+- Deployment Name: Unique identifier for an agent deployment
 - Collection: Named grouping of data within an agent (defaults to "default"). Data within a collection should be of the same type.
 - Agent Data: Individual structured data records with metadata and timestamps
 
@@ -26,7 +26,7 @@ Example Usage:
         client=async_llama_cloud,
         type=Person,
         collection="people",
-        agent_url_id="my-extraction-agent-xyz"
+        deployment_name="my-extraction-agent-xyz"
     )
 
     # Create typed data
@@ -78,7 +78,7 @@ class TypedAgentData(BaseModel, Generic[AgentDataT]):
 
     Attributes:
         id: Unique identifier for this data record
-        agent_url_id: Identifier of the agent that created this data
+        deployment_name: Identifier of the agent deployment that created this data
         collection: Named collection within the agent (used for organization)
         data: The actual structured data payload (typed as AgentDataT)
         created_at: Timestamp when the record was first created
@@ -94,8 +94,8 @@ class TypedAgentData(BaseModel, Generic[AgentDataT]):
     """
 
     id: Optional[str] = Field(description="Unique identifier for this data record")
-    agent_url_id: str = Field(
-        description="Identifier of the agent that created this data"
+    deployment_name: str = Field(
+        description="Identifier of the agent deployment that created this data"
     )
     collection: Optional[str] = Field(
         description="Named collection within the agent for data organization"
@@ -124,7 +124,7 @@ class TypedAgentData(BaseModel, Generic[AgentDataT]):
 
         return cls(
             id=raw_data.id,
-            agent_url_id=raw_data.agent_slug,
+            deployment_name=raw_data.deployment_name,
             collection=raw_data.collection,
             data=data,
             created_at=raw_data.created_at,

--- a/py/llama_parse/pyproject.toml
+++ b/py/llama_parse/pyproject.toml
@@ -11,13 +11,13 @@ dev = [
 
 [project]
 name = "llama-parse"
-version = "0.6.66"
+version = "0.6.67"
 description = "Parse files into RAG-Optimized formats."
 authors = [{name = "Logan Markewich", email = "logan@llamaindex.ai"}]
 requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"
-dependencies = ["llama-cloud-services>=0.6.66"]
+dependencies = ["llama-cloud-services>=0.6.67"]
 
 [project.scripts]
 llama-parse = "llama_parse.cli.main:parse"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -27,7 +27,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
   "llama-index-core>=0.12.0",
-  "llama-cloud==0.1.41",
+  "llama-cloud==0.1.42",
   "pydantic>=2.8,!=2.10",
   "click>=8.1.7,<9",
   "python-dotenv>=1.0.1,<2",

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
 
 [project]
 name = "llama-cloud-services"
-version = "0.6.66"
+version = "0.6.67"
 description = "Tailored SDK clients for LlamaCloud services."
 authors = [{name = "Logan Markewich", email = "logan@runllama.ai"}]
 requires-python = ">=3.9,<4.0"

--- a/py/tests/beta/agent_data/test_agent_data_client.py
+++ b/py/tests/beta/agent_data/test_agent_data_client.py
@@ -68,7 +68,7 @@ async def test_agent_data_crud_operations():
         client=client,
         type=ExampleData,
         collection=f"test-collection-{test_id[:8]}",
-        agent_url_id=LLAMA_DEPLOY_DEPLOYMENT_NAME,
+        deployment_name=LLAMA_DEPLOY_DEPLOYMENT_NAME,
     )
 
     # Create test data

--- a/py/unit_tests/beta/agent/test_agent_data_schema.py
+++ b/py/unit_tests/beta/agent/test_agent_data_schema.py
@@ -38,7 +38,7 @@ def test_typed_agent_data_from_raw():
     """Test TypedAgentData.from_raw class method."""
     raw_data = AgentData(
         id="456",
-        agent_slug="extraction-agent",
+        deployment_name="extraction-agent",
         collection="employees",
         data={"name": "Jane Smith", "age": 25, "email": "jane@company.com"},
         created_at=datetime.now(),
@@ -48,7 +48,7 @@ def test_typed_agent_data_from_raw():
     typed_data = TypedAgentData.from_raw(raw_data, Person)
 
     assert typed_data.id == "456"
-    assert typed_data.agent_url_id == "extraction-agent"
+    assert typed_data.deployment_name == "extraction-agent"
     assert typed_data.collection == "employees"
     assert typed_data.data.name == "Jane Smith"
     assert typed_data.data.age == 25
@@ -59,7 +59,7 @@ def test_typed_agent_data_from_raw_validation_error():
     """Test TypedAgentData.from_raw with invalid data."""
     raw_data = AgentData(
         id="789",
-        agent_slug="test-agent",
+        deployment_name="test-agent",
         collection="people",
         data={"name": "Invalid Person", "age": "not_a_number"},  # Invalid age
         created_at=datetime.now(),

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1582,21 +1582,21 @@ wheels = [
 
 [[package]]
 name = "llama-cloud"
-version = "0.1.41"
+version = "0.1.42"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/6c/b2e84eebed376aea34c446cab745da5fc4e9dc53309180672299083219d5/llama_cloud-0.1.41.tar.gz", hash = "sha256:dcb741b779e3e740cd64928cfffc8ef70ed0e9bae9ef26acbe1d7e32aa737bdc", size = 109854, upload-time = "2025-09-05T22:45:13.069Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/04/ae0694b582d6aab4d6e7957febb7bff048897ac231ad80ba1bd71547d944/llama_cloud-0.1.42.tar.gz", hash = "sha256:485aa0e364ea648e3aaa3b2c54af7bcb6f2242c50b4f86ec022e137413fff464", size = 112480, upload-time = "2025-09-16T20:25:42.631Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/4d/f0af76b389310840ce3483a92560a152025b0eefe4eee0c81102bf3317e6/llama_cloud-0.1.41-py3-none-any.whl", hash = "sha256:c847f288f0d3f4b23f47345088006deae5f2cf3f223ac1819d4c1531e9aaa13e", size = 307646, upload-time = "2025-09-05T22:45:11.597Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/61/85d115699a59d03f0783e119aaf6d534fca95dbe1a4531a8056e6a4774ed/llama_cloud-0.1.42-py3-none-any.whl", hash = "sha256:4ed3edde4a277ff52eeb831188c8476eb079b5e4605ad3142157a0f054b27d96", size = 311857, upload-time = "2025-09-16T20:25:41.479Z" },
 ]
 
 [[package]]
 name = "llama-cloud-services"
-version = "0.6.65"
+version = "0.6.66"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -1631,7 +1631,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.7,<9" },
     { name = "eval-type-backport", marker = "python_full_version < '3.10'", specifier = ">=0.2.0,<0.3" },
-    { name = "llama-cloud", specifier = "==0.1.41" },
+    { name = "llama-cloud", specifier = "==0.1.42" },
     { name = "llama-index-core", specifier = ">=0.12.0" },
     { name = "packaging", specifier = ">=25.0" },
     { name = "platformdirs", specifier = ">=4.3.7,<5" },

--- a/ts/llama_cloud_services/openapi.json
+++ b/ts/llama_cloud_services/openapi.json
@@ -18764,9 +18764,9 @@
             ],
             "title": "Id"
           },
-          "agent_slug": {
+          "deployment_name": {
             "type": "string",
-            "title": "Agent Slug"
+            "title": "Deployment Name"
           },
           "collection": {
             "type": "string",
@@ -18805,7 +18805,7 @@
         },
         "type": "object",
         "required": [
-          "agent_slug",
+          "deployment_name",
           "data"
         ],
         "title": "AgentData",
@@ -18813,9 +18813,9 @@
       },
       "AgentDataCreate": {
         "properties": {
-          "agent_slug": {
+          "deployment_name": {
             "type": "string",
-            "title": "Agent Slug"
+            "title": "Deployment Name"
           },
           "collection": {
             "type": "string",
@@ -18830,7 +18830,7 @@
         },
         "type": "object",
         "required": [
-          "agent_slug",
+          "deployment_name",
           "data"
         ],
         "title": "AgentDataCreate",
@@ -18881,9 +18881,9 @@
             "title": "Project Id",
             "description": "Project ID"
           },
-          "agent_slug": {
+          "deployment_name": {
             "type": "string",
-            "title": "Agent Slug",
+            "title": "Deployment Name",
             "description": "readable ID of the deployed app"
           },
           "thumbnail_url": {
@@ -18938,7 +18938,7 @@
         "required": [
           "id",
           "project_id",
-          "agent_slug",
+          "deployment_name",
           "base_url",
           "display_name",
           "created_at",
@@ -19037,10 +19037,10 @@
             "title": "Order By",
             "description": "A comma-separated list of fields to order by, sorted in ascending order. Use 'field_name desc' to specify descending order."
           },
-          "agent_slug": {
+          "deployment_name": {
             "type": "string",
-            "title": "Agent Slug",
-            "description": "The agent deployment's agent_slug to aggregate data for"
+            "title": "Deployment Name",
+            "description": "The agent deployment's deployment_name to aggregate data for"
           },
           "collection": {
             "type": "string",
@@ -19107,7 +19107,7 @@
         },
         "type": "object",
         "required": [
-          "agent_slug"
+          "deployment_name"
         ],
         "title": "AggregateRequest",
         "description": "API request body for aggregating agent data"
@@ -37237,10 +37237,10 @@
             "title": "Order By",
             "description": "A comma-separated list of fields to order by, sorted in ascending order. Use 'field_name desc' to specify descending order."
           },
-          "agent_slug": {
+          "deployment_name": {
             "type": "string",
-            "title": "Agent Slug",
-            "description": "The agent deployment's agent_slug to search within"
+            "title": "Deployment Name",
+            "description": "The agent deployment's deployment_name to search within"
           },
           "collection": {
             "type": "string",
@@ -37272,7 +37272,7 @@
         },
         "type": "object",
         "required": [
-          "agent_slug"
+          "deployment_name"
         ],
         "title": "SearchRequest",
         "description": "API request body for searching agent data"

--- a/ts/llama_cloud_services/openapi.json
+++ b/ts/llama_cloud_services/openapi.json
@@ -339,79 +339,6 @@
             }
           }
         }
-      },
-      "put": {
-        "tags": [
-          "API Keys"
-        ],
-        "summary": "Update Existing Api Key",
-        "description": "Update name of an existing API Key.",
-        "operationId": "update_existing_api_key_api_v1_api_keys__api_key_id__put",
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "api_key_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Api Key Id"
-            }
-          },
-          {
-            "name": "session",
-            "in": "cookie",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Session"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/APIKeyUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIKey"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/api/v1/validate-integrations/validate-embedding-connection": {
@@ -9014,6 +8941,78 @@
         }
       }
     },
+    "/api/v1/pipelines/{pipeline_id}/documents/{document_id}/sync": {
+      "post": {
+        "tags": [
+          "Pipelines"
+        ],
+        "summary": "Sync Pipeline Document",
+        "description": "Sync a specific document for a pipeline.",
+        "operationId": "sync_pipeline_document_api_v1_pipelines__pipeline_id__documents__document_id__sync_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          },
+          {
+            "name": "pipeline_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Pipeline Id"
+            }
+          },
+          {
+            "name": "session",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Session"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/pipelines/{pipeline_id}/documents/{document_id}/chunks": {
       "get": {
         "tags": [
@@ -9076,6 +9075,93 @@
                   },
                   "title": "Response List Pipeline Document Chunks Api V1 Pipelines  Pipeline Id  Documents  Document Id  Chunks Get"
                 }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pipelines/{pipeline_id}/documents/force-sync-all": {
+      "post": {
+        "tags": [
+          "Pipelines"
+        ],
+        "summary": "Force Sync All Pipeline Documents",
+        "description": "Force sync all documents in a pipeline by batching document ingestion jobs.\n\n- Iterates all document refs for the pipeline\n- Enqueues document ingestion jobs in batches of `batch_size`",
+        "operationId": "force_sync_all_pipeline_documents_api_v1_pipelines__pipeline_id__documents_force_sync_all_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "pipeline_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Pipeline Id"
+            }
+          },
+          {
+            "name": "batch_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 50,
+              "title": "Batch Size"
+            }
+          },
+          {
+            "name": "only_failed",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Only sync retriable documents (failed/cancelled/not-started/stalled-in-progress)",
+              "default": true,
+              "title": "Only Failed"
+            },
+            "description": "Only sync retriable documents (failed/cancelled/not-started/stalled-in-progress)"
+          },
+          {
+            "name": "session",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Session"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
               }
             }
           },
@@ -14700,6 +14786,330 @@
         }
       }
     },
+    "/api/v1/beta/api-keys": {
+      "post": {
+        "tags": [
+          "Beta",
+          "API Keys V2"
+        ],
+        "summary": "Create Api Key",
+        "description": "Create a new API key.\n\nIf project_id is specified, validates user has admin permissions for that project.\n\nArgs:\n    api_key_create: API key creation data\n    user: Current user\n    db: Database session\n\nReturns:\n    The created API key with the secret key visible in redacted_api_key field",
+        "operationId": "create_api_key_api_v1_beta_api_keys_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Session"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/APIKeyCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKey"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Beta",
+          "API Keys V2"
+        ],
+        "summary": "List Api Keys",
+        "description": "List API keys.\n\nIf project_id is provided, validates user has access to that project.\nIf project_id is not provided, scopes results to the current user.\n\nArgs:\n    user: Current user\n    db: Database session\n    page_size: Number of items per page\n    page_token: Token for pagination\n    name: Filter by API key name\n    project_id: Filter by project ID\n    key_type: Filter by key type\n\nReturns:\n    Paginated response with API keys",
+        "operationId": "list_api_keys_api_v1_beta_api_keys_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "name": "page_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Token"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Name"
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "key_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/APIKeyType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Key Type"
+            }
+          },
+          {
+            "name": "session",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Session"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyQueryResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/beta/api-keys/{api_key_id}": {
+      "get": {
+        "tags": [
+          "Beta",
+          "API Keys V2"
+        ],
+        "summary": "Get Api Key",
+        "description": "Get an API key by ID.\n\nArgs:\n    api_key_id: The ID of the API key\n    user: Current user\n    db: Database session\n\nReturns:\n    The API key",
+        "operationId": "get_api_key_api_v1_beta_api_keys__api_key_id__get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "api_key_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Api Key Id"
+            }
+          },
+          {
+            "name": "session",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Session"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKey"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Beta",
+          "API Keys V2"
+        ],
+        "summary": "Delete Api Key",
+        "description": "Delete an API key.\n\nIf the API key belongs to a project, validates user has admin permissions for that project.\nIf the API key has no project, validates it belongs to the current user.\n\nArgs:\n    api_key_id: The ID of the API key to delete\n    user: Current user\n    db: Database session",
+        "operationId": "delete_api_key_api_v1_beta_api_keys__api_key_id__delete",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "api_key_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Api Key Id"
+            }
+          },
+          {
+            "name": "session",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Session"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/beta/batches": {
       "post": {
         "tags": [
@@ -18675,6 +19085,48 @@
         "title": "APIKeyCreate",
         "description": "Schema for creating an API key."
       },
+      "APIKeyQueryResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/APIKey"
+            },
+            "type": "array",
+            "title": "Items",
+            "description": "The list of items."
+          },
+          "next_page_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Page Token",
+            "description": "A token, which can be sent as page_token to retrieve the next page. If this field is omitted, there are no subsequent pages."
+          },
+          "total_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Size",
+            "description": "The total number of items available. This is only populated when specifically requested. The value may be an estimate and can be used for display purposes only."
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "APIKeyQueryResponse",
+        "description": "Response schema for paginated API key queries."
+      },
       "APIKeyType": {
         "type": "string",
         "enum": [
@@ -18682,26 +19134,6 @@
           "agent"
         ],
         "title": "APIKeyType"
-      },
-      "APIKeyUpdate": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 3000,
-                "minLength": 0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          }
-        },
-        "type": "object",
-        "title": "APIKeyUpdate",
-        "description": "Schema for updating an API key."
       },
       "AdvancedModeTransformConfig": {
         "properties": {
@@ -18884,7 +19316,7 @@
           "deployment_name": {
             "type": "string",
             "title": "Deployment Name",
-            "description": "readable ID of the deployed app"
+            "description": "Identifier of the deployed app"
           },
           "thumbnail_url": {
             "anyOf": [
@@ -18902,11 +19334,6 @@
             "type": "string",
             "title": "Base Url",
             "description": "Base URL of the deployed app"
-          },
-          "display_name": {
-            "type": "string",
-            "title": "Display Name",
-            "description": "Display name of the deployed app"
           },
           "created_at": {
             "type": "string",
@@ -18940,7 +19367,6 @@
           "project_id",
           "deployment_name",
           "base_url",
-          "display_name",
           "created_at",
           "updated_at"
         ],
@@ -19040,7 +19466,7 @@
           "deployment_name": {
             "type": "string",
             "title": "Deployment Name",
-            "description": "The agent deployment's deployment_name to aggregate data for"
+            "description": "The agent deployment's name to aggregate data for"
           },
           "collection": {
             "type": "string",
@@ -19093,8 +19519,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 1000,
-                "minimum": 0
+                "maximum": 1000.0,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -19146,7 +19572,7 @@
           },
           "chunk_size": {
             "type": "integer",
-            "exclusiveMinimum": 0,
+            "exclusiveMinimum": 0.0,
             "title": "Chunk Size",
             "description": "Chunk size for the transformation.",
             "default": 1024
@@ -19172,8 +19598,8 @@
           },
           "embed_batch_size": {
             "type": "integer",
-            "maximum": 2048,
-            "exclusiveMinimum": 0,
+            "maximum": 2048.0,
+            "exclusiveMinimum": 0.0,
             "title": "Embed Batch Size",
             "description": "The batch size for embedding calls.",
             "default": 10
@@ -19231,7 +19657,7 @@
             "type": "number",
             "title": "Timeout",
             "description": "Timeout for each request.",
-            "default": 60,
+            "default": 60.0,
             "gte": 0
           },
           "default_headers": {
@@ -19870,8 +20296,8 @@
           },
           "embed_batch_size": {
             "type": "integer",
-            "maximum": 2048,
-            "exclusiveMinimum": 0,
+            "maximum": 2048.0,
+            "exclusiveMinimum": 0.0,
             "title": "Embed Batch Size",
             "description": "The batch size for embedding calls.",
             "default": 10
@@ -19950,7 +20376,7 @@
           },
           "max_retries": {
             "type": "integer",
-            "exclusiveMinimum": 0,
+            "exclusiveMinimum": 0.0,
             "title": "Max Retries",
             "description": "The maximum number of API retries.",
             "default": 10
@@ -19959,7 +20385,7 @@
             "type": "number",
             "title": "Timeout",
             "description": "The timeout for the Bedrock API request in seconds. It will be used for both connect and read timeouts.",
-            "default": 60
+            "default": 60.0
           },
           "additional_kwargs": {
             "additionalProperties": true,
@@ -20428,9 +20854,14 @@
             "title": "Specialized Chart Parsing Efficient",
             "default": false
           },
-          "precise_bbox_extraction": {
+          "specialized_image_parsing": {
             "type": "boolean",
-            "title": "Precise Bbox Extraction",
+            "title": "Specialized Image Parsing",
+            "default": false
+          },
+          "precise_bounding_box": {
+            "type": "boolean",
+            "title": "Precise Bounding Box",
             "default": false
           },
           "html_remove_fixed_elements": {
@@ -20550,6 +20981,16 @@
             "type": "boolean",
             "title": "Spreadsheet Extract Sub Tables",
             "default": true
+          },
+          "spreadsheet_force_formula_computation": {
+            "type": "boolean",
+            "title": "Spreadsheet Force Formula Computation",
+            "default": false
+          },
+          "inline_images_in_markdown": {
+            "type": "boolean",
+            "title": "Inline Images In Markdown",
+            "default": false
           },
           "structured_output": {
             "type": "boolean",
@@ -20953,9 +21394,14 @@
             "title": "Specialized Chart Parsing Efficient",
             "default": false
           },
-          "precise_bbox_extraction": {
+          "specialized_image_parsing": {
             "type": "boolean",
-            "title": "Precise Bbox Extraction",
+            "title": "Specialized Image Parsing",
+            "default": false
+          },
+          "precise_bounding_box": {
+            "type": "boolean",
+            "title": "Precise Bounding Box",
             "default": false
           },
           "html_remove_fixed_elements": {
@@ -21075,6 +21521,16 @@
             "type": "boolean",
             "title": "Spreadsheet Extract Sub Tables",
             "default": true
+          },
+          "spreadsheet_force_formula_computation": {
+            "type": "boolean",
+            "title": "Spreadsheet Force Formula Computation",
+            "default": false
+          },
+          "inline_images_in_markdown": {
+            "type": "boolean",
+            "title": "Inline Images In Markdown",
+            "default": false
           },
           "structured_output": {
             "type": "boolean",
@@ -21348,7 +21804,7 @@
         "properties": {
           "chunk_size": {
             "type": "integer",
-            "exclusiveMinimum": 0,
+            "exclusiveMinimum": 0.0,
             "title": "Chunk Size",
             "default": 1024
           },
@@ -21715,8 +22171,8 @@
           },
           "confidence": {
             "type": "number",
-            "maximum": 1,
-            "minimum": 0,
+            "maximum": 1.0,
+            "minimum": 0.0,
             "title": "Confidence",
             "description": "Confidence score of the classification (0.0-1.0)"
           },
@@ -23588,8 +24044,8 @@
           },
           "embed_batch_size": {
             "type": "integer",
-            "maximum": 2048,
-            "exclusiveMinimum": 0,
+            "maximum": 2048.0,
+            "exclusiveMinimum": 0.0,
             "title": "Embed Batch Size",
             "description": "The batch size for embedding calls.",
             "default": 10
@@ -23978,10 +24434,10 @@
             "description": "Whether the user is allowed to access API data sources.",
             "default": false
           },
-          "allowed_deployment": {
+          "allow_org_deletion": {
             "type": "boolean",
-            "title": "Allowed Deployment",
-            "description": "Whether the user is allowed to access the deployment.",
+            "title": "Allow Org Deletion",
+            "description": "Whether the user is allowed to delete organizations.",
             "default": false
           }
         },
@@ -26462,7 +26918,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "minimum": 0
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -26752,7 +27208,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "minimum": 0
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -27495,8 +27951,8 @@
           },
           "embed_batch_size": {
             "type": "integer",
-            "maximum": 2048,
-            "exclusiveMinimum": 0,
+            "maximum": 2048.0,
+            "exclusiveMinimum": 0.0,
             "title": "Embed Batch Size",
             "description": "The batch size for embedding calls.",
             "default": 10
@@ -27630,8 +28086,8 @@
           },
           "embed_batch_size": {
             "type": "integer",
-            "maximum": 2048,
-            "exclusiveMinimum": 0,
+            "maximum": 2048.0,
+            "exclusiveMinimum": 0.0,
             "title": "Embed Batch Size",
             "description": "The batch size for embedding calls.",
             "default": 10
@@ -28567,6 +29023,19 @@
             "description": "Whether to extract subTables from spreadsheet.",
             "default": false
           },
+          "spreadSheetForceFormulaComputation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spreadsheetforceformulacomputation",
+            "description": "Whether to force re-computation of spreadsheet cells containing formulas.",
+            "default": false
+          },
           "extractLayout": {
             "anyOf": [
               {
@@ -29402,7 +29871,8 @@
               "specialized_chart_parsing_agentic": false,
               "specialized_chart_parsing_plus": false,
               "specialized_chart_parsing_efficient": false,
-              "precise_bbox_extraction": false,
+              "specialized_image_parsing": false,
+              "precise_bounding_box": false,
               "html_remove_navigation_elements": false,
               "html_remove_fixed_elements": false,
               "guess_xlsx_sheet_name": false,
@@ -29419,6 +29889,8 @@
               "structured_output": false,
               "extract_charts": false,
               "spreadsheet_extract_sub_tables": false,
+              "spreadsheet_force_formula_computation": false,
+              "inline_images_in_markdown": false,
               "strict_mode_image_extraction": false,
               "strict_mode_image_ocr": false,
               "strict_mode_reconstruction": false,
@@ -29798,7 +30270,7 @@
             "title": "Specialized Chart Parsing Efficient",
             "default": false
           },
-          "precise_bbox_extraction": {
+          "specialized_image_parsing": {
             "anyOf": [
               {
                 "type": "boolean"
@@ -29807,7 +30279,19 @@
                 "type": "null"
               }
             ],
-            "title": "Precise Bbox Extraction",
+            "title": "Specialized Image Parsing",
+            "default": false
+          },
+          "precise_bounding_box": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Precise Bounding Box",
             "default": false
           },
           "html_remove_navigation_elements": {
@@ -30363,6 +30847,30 @@
             "title": "Spreadsheet Extract Sub Tables",
             "default": false
           },
+          "spreadsheet_force_formula_computation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spreadsheet Force Formula Computation",
+            "default": false
+          },
+          "inline_images_in_markdown": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Inline Images In Markdown",
+            "default": false
+          },
           "job_timeout_in_seconds": {
             "anyOf": [
               {
@@ -30854,8 +31362,8 @@
           },
           "embed_batch_size": {
             "type": "integer",
-            "maximum": 2048,
-            "exclusiveMinimum": 0,
+            "maximum": 2048.0,
+            "exclusiveMinimum": 0.0,
             "title": "Embed Batch Size",
             "description": "The batch size for embedding calls.",
             "default": 10
@@ -31113,8 +31621,8 @@
           },
           "embed_batch_size": {
             "type": "integer",
-            "maximum": 2048,
-            "exclusiveMinimum": 0,
+            "maximum": 2048.0,
+            "exclusiveMinimum": 0.0,
             "title": "Embed Batch Size",
             "description": "The batch size for embedding calls.",
             "default": 10
@@ -31186,7 +31694,7 @@
             "type": "number",
             "title": "Timeout",
             "description": "Timeout for each request.",
-            "default": 60,
+            "default": 60.0,
             "gte": 0
           },
           "default_headers": {
@@ -31305,6 +31813,19 @@
             "$ref": "#/components/schemas/ParsePlanLevel",
             "description": "Whether the organization is a Parse Premium customer.",
             "default": "DEFAULT"
+          },
+          "feature_flags": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feature Flags",
+            "description": "Feature flags for the organization."
           }
         },
         "type": "object",
@@ -31340,6 +31861,19 @@
             "minLength": 1,
             "title": "Name",
             "description": "A name for the organization."
+          },
+          "feature_flags": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feature Flags",
+            "description": "Feature flags for the organization."
           }
         },
         "type": "object",
@@ -31366,21 +31900,21 @@
         "properties": {
           "ef_construction": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 1.0,
             "title": "Ef Construction",
             "description": "The number of edges to use during the construction phase.",
             "default": 64
           },
           "ef_search": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 1.0,
             "title": "Ef Search",
             "description": "The number of edges to use during the search phase.",
             "default": 40
           },
           "m": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 1.0,
             "title": "M",
             "description": "The number of bi-directional links created for each new element.",
             "default": 16
@@ -31426,13 +31960,13 @@
           },
           "page_index": {
             "type": "integer",
-            "minimum": 0,
+            "minimum": 0.0,
             "title": "Page Index",
             "description": "The index of the page for which the figure is taken (0-indexed)"
           },
           "figure_size": {
             "type": "integer",
-            "minimum": 0,
+            "minimum": 0.0,
             "title": "Figure Size",
             "description": "The size of the figure in bytes"
           },
@@ -31444,8 +31978,8 @@
           },
           "confidence": {
             "type": "number",
-            "maximum": 1,
-            "minimum": 0,
+            "maximum": 1.0,
+            "minimum": 0.0,
             "title": "Confidence",
             "description": "The confidence of the figure"
           },
@@ -31501,7 +32035,7 @@
         "properties": {
           "page_index": {
             "type": "integer",
-            "minimum": 0,
+            "minimum": 0.0,
             "title": "Page Index",
             "description": "The index of the page for which the screenshot is taken (0-indexed)"
           },
@@ -31513,7 +32047,7 @@
           },
           "image_size": {
             "type": "integer",
-            "minimum": 0,
+            "minimum": 0.0,
             "title": "Image Size",
             "description": "The size of the image in bytes"
           },
@@ -32584,7 +33118,7 @@
             "title": "Specialized Chart Parsing Efficient",
             "default": false
           },
-          "precise_bbox_extraction": {
+          "specialized_image_parsing": {
             "anyOf": [
               {
                 "type": "boolean"
@@ -32593,7 +33127,19 @@
                 "type": "null"
               }
             ],
-            "title": "Precise Bbox Extraction",
+            "title": "Specialized Image Parsing",
+            "default": false
+          },
+          "precise_bounding_box": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Precise Bounding Box",
             "default": false
           },
           "html_remove_navigation_elements": {
@@ -33151,6 +33697,30 @@
               }
             ],
             "title": "Spreadsheet Extract Sub Tables",
+            "default": false
+          },
+          "spreadsheet_force_formula_computation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spreadsheet Force Formula Computation",
+            "default": false
+          },
+          "inline_images_in_markdown": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Inline Images In Markdown",
             "default": false
           },
           "job_timeout_in_seconds": {
@@ -34756,7 +35326,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "minimum": 0
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -35937,8 +36507,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 100,
-                "minimum": 1
+                "maximum": 100.0,
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -35952,8 +36522,8 @@
             "anyOf": [
               {
                 "type": "number",
-                "maximum": 1,
-                "minimum": 0
+                "maximum": 1.0,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -35961,14 +36531,14 @@
             ],
             "title": "Dense Similarity Cutoff",
             "description": "Minimum similarity score wrt query for retrieval",
-            "default": 0
+            "default": 0.0
           },
           "sparse_similarity_top_k": {
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 100,
-                "minimum": 1
+                "maximum": 100.0,
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -35994,8 +36564,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 100,
-                "minimum": 1
+                "maximum": 100.0,
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -36009,8 +36579,8 @@
             "anyOf": [
               {
                 "type": "number",
-                "maximum": 1,
-                "minimum": 0
+                "maximum": 1.0,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -36073,8 +36643,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 5,
-                "minimum": 1
+                "maximum": 5.0,
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -36358,7 +36928,8 @@
               "rate_limit_parse_concurrent_premium",
               "rate_limit_parse_concurrent_default",
               "rate_limit_concurrent_jobs_in_execution_default",
-              "rate_limit_concurrent_jobs_in_execution_doc_ingest"
+              "rate_limit_concurrent_jobs_in_execution_doc_ingest",
+              "limit_embedding_character"
             ],
             "title": "Configuration Type",
             "description": "The quota configuration type"
@@ -36679,8 +37250,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 100,
-                "minimum": 1
+                "maximum": 100.0,
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -36694,8 +37265,8 @@
             "anyOf": [
               {
                 "type": "number",
-                "maximum": 1,
-                "minimum": 0
+                "maximum": 1.0,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -36703,14 +37274,14 @@
             ],
             "title": "Dense Similarity Cutoff",
             "description": "Minimum similarity score wrt query for retrieval",
-            "default": 0
+            "default": 0.0
           },
           "sparse_similarity_top_k": {
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 100,
-                "minimum": 1
+                "maximum": 100.0,
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -36736,8 +37307,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 100,
-                "minimum": 1
+                "maximum": 100.0,
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -36751,8 +37322,8 @@
             "anyOf": [
               {
                 "type": "number",
-                "maximum": 1,
-                "minimum": 0
+                "maximum": 1.0,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -36815,8 +37386,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 5,
-                "minimum": 1
+                "maximum": 5.0,
+                "minimum": 1.0
               },
               {
                 "type": "null"
@@ -37240,7 +37811,7 @@
           "deployment_name": {
             "type": "string",
             "title": "Deployment Name",
-            "description": "The agent deployment's deployment_name to search within"
+            "description": "The agent deployment's name to search within"
           },
           "collection": {
             "type": "string",
@@ -37258,8 +37829,8 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 1000,
-                "minimum": 0
+                "maximum": 1000.0,
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -37303,7 +37874,7 @@
         "properties": {
           "chunk_size": {
             "type": "integer",
-            "exclusiveMinimum": 0,
+            "exclusiveMinimum": 0.0,
             "title": "Chunk Size",
             "default": 1024
           },
@@ -37394,7 +37965,7 @@
             "type": "number",
             "title": "Temperature",
             "description": "The temperature to use for the structured parsing.",
-            "default": 0
+            "default": 0.0
           },
           "relaxation_mode": {
             "$ref": "#/components/schemas/SchemaRelaxMode",
@@ -37659,7 +38230,7 @@
         "properties": {
           "chunk_size": {
             "type": "integer",
-            "exclusiveMinimum": 0,
+            "exclusiveMinimum": 0.0,
             "title": "Chunk Size",
             "default": 1024
           },
@@ -38308,8 +38879,8 @@
           },
           "embed_batch_size": {
             "type": "integer",
-            "maximum": 2048,
-            "exclusiveMinimum": 0,
+            "maximum": 2048.0,
+            "exclusiveMinimum": 0.0,
             "title": "Embed Batch Size",
             "description": "The batch size for embedding calls.",
             "default": 10

--- a/ts/llama_cloud_services/package.json
+++ b/ts/llama_cloud_services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llama-cloud-services",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/ts/llama_cloud_services/src/beta/agent/client.ts
+++ b/ts/llama_cloud_services/src/beta/agent/client.ts
@@ -31,14 +31,17 @@ export class AgentClient<T = unknown> {
     client = defaultClient,
     collection = "default",
     deploymentName = "_public",
+    agentUrlId,
   }: {
     client?: ReturnType<typeof createClient>;
     collection?: string;
     deploymentName?: string;
+    // deprecated, use deploymentName instead
+    agentUrlId?: string;
   }) {
     this.client = client;
     this.collection = collection;
-    this.deploymentName = deploymentName;
+    this.deploymentName = agentUrlId || deploymentName;
   }
 
   /**
@@ -268,12 +271,15 @@ export function createAgentDataClient<T = unknown>({
   windowUrl,
   env,
   deploymentName,
+  agentUrlId,
   collection = "default",
 }: {
   client?: ReturnType<typeof createClient>;
   windowUrl?: string;
   env?: Record<string, string>;
   deploymentName?: string;
+  // deprecated, use deploymentName instead
+  agentUrlId?: string;
   collection?: string;
 } = {}): AgentClient<T> {
   if (env && !deploymentName) {
@@ -303,6 +309,7 @@ export function createAgentDataClient<T = unknown>({
 
   return new AgentClient({
     ...(deploymentName && { deploymentName }),
+    ...(agentUrlId && { agentUrlId }),
     collection,
     client,
   });

--- a/ts/llama_cloud_services/src/beta/agent/client.ts
+++ b/ts/llama_cloud_services/src/beta/agent/client.ts
@@ -25,20 +25,20 @@ import type {
 export class AgentClient<T = unknown> {
   private client: ReturnType<typeof createClient>;
   private collection: string;
-  private agentUrlId: string;
+  private deploymentName: string;
 
   constructor({
     client = defaultClient,
     collection = "default",
-    agentUrlId = "_public",
+    deploymentName = "_public",
   }: {
     client?: ReturnType<typeof createClient>;
     collection?: string;
-    agentUrlId?: string;
+    deploymentName?: string;
   }) {
     this.client = client;
     this.collection = collection;
-    this.agentUrlId = agentUrlId;
+    this.deploymentName = deploymentName;
   }
 
   /**
@@ -48,7 +48,7 @@ export class AgentClient<T = unknown> {
     const response = await createAgentDataApiV1BetaAgentDataPost({
       throwOnError: true,
       body: {
-        agent_slug: this.agentUrlId,
+        deployment_name: this.deploymentName,
         collection: this.collection,
         data: data as Record<string, unknown>,
       },
@@ -118,7 +118,7 @@ export class AgentClient<T = unknown> {
     const response = await searchAgentDataApiV1BetaAgentDataSearchPost({
       throwOnError: true,
       body: {
-        agent_slug: this.agentUrlId,
+        deployment_name: this.deploymentName,
         ...(this.collection !== undefined && {
           collection: this.collection,
         }),
@@ -165,7 +165,7 @@ export class AgentClient<T = unknown> {
     const response = await aggregateAgentDataApiV1BetaAgentDataAggregatePost({
       throwOnError: true,
       body: {
-        agent_slug: this.agentUrlId,
+        deployment_name: this.deploymentName,
         ...(this.collection !== undefined && {
           collection: this.collection,
         }),
@@ -209,7 +209,7 @@ export class AgentClient<T = unknown> {
   private transformResponse(data: AgentData): TypedAgentData<T> {
     const result: TypedAgentData<T> = {
       id: data.id!,
-      agentUrlId: data.agent_slug,
+      deploymentName: (data as any).deployment_name,
       data: data.data as T,
       createdAt: new Date(data.created_at!),
       updatedAt: new Date(data.updated_at!),
@@ -250,10 +250,10 @@ export interface AgentDataClientOptions {
   /** Base URL for the client */
   /** Base URL of the llama cloud api */
   baseUrl?: string;
-  /** If running in an agent runtime, optionally provide the window url to infer the agent url id */
+  /** If running in an agent runtime, optionally provide the window url to infer the deployment name */
   windowUrl?: string;
-  /** Agent URL ID for the client, if not provided, it will be inferred from the window url, or fall back to "default" */
-  agentUrlId?: string;
+  /** Deployment name for the client, if not provided, it will be inferred from the window url, or fall back to "default" */
+  deploymentName?: string;
   /** Collection name for the client, defaults to "default" */
   collection?: string;
 }
@@ -267,22 +267,22 @@ export function createAgentDataClient<T = unknown>({
   client = defaultClient,
   windowUrl,
   env,
-  agentUrlId,
+  deploymentName,
   collection = "default",
 }: {
   client?: ReturnType<typeof createClient>;
   windowUrl?: string;
   env?: Record<string, string>;
-  agentUrlId?: string;
+  deploymentName?: string;
   collection?: string;
 } = {}): AgentClient<T> {
-  if (env && !agentUrlId) {
-    agentUrlId =
+  if (env && !deploymentName) {
+    deploymentName =
       env.LLAMA_DEPLOY_DEPLOYMENT_NAME ||
       env.NEXT_PUBLIC_LLAMA_DEPLOY_DEPLOYMENT_NAME ||
       env.VITE_LLAMA_DEPLOY_DEPLOYMENT_NAME;
   }
-  if (windowUrl && !agentUrlId) {
+  if (windowUrl && !deploymentName) {
     try {
       const url = new URL(windowUrl);
       const path = url.pathname;
@@ -291,18 +291,18 @@ export function createAgentDataClient<T = unknown>({
         url.hostname.includes("127.0.0.1");
       if (path.startsWith("/deployments/") && !isLocalhost) {
         // /deployments/<agent-url-id>/ui/ -> ["", "deployments", "<agent-url-id>", "ui"]
-        agentUrlId = path.split("/")[2];
+        deploymentName = path.split("/")[2];
       }
     } catch (error) {
       console.warn(
-        "Failed to infer agent url id from window url, falling back to default",
+        "Failed to infer deployment name from window url, falling back to default",
         error,
       );
     }
   }
 
   return new AgentClient({
-    ...(agentUrlId && { agentUrlId }),
+    ...(deploymentName && { deploymentName }),
     collection,
     client,
   });

--- a/ts/llama_cloud_services/src/beta/agent/client.ts
+++ b/ts/llama_cloud_services/src/beta/agent/client.ts
@@ -209,7 +209,7 @@ export class AgentClient<T = unknown> {
   private transformResponse(data: AgentData): TypedAgentData<T> {
     const result: TypedAgentData<T> = {
       id: data.id!,
-      deploymentName: (data as any).deployment_name,
+      deploymentName: data.deployment_name,
       data: data.data as T,
       createdAt: new Date(data.created_at!),
       updatedAt: new Date(data.updated_at!),

--- a/ts/llama_cloud_services/src/beta/agent/types.ts
+++ b/ts/llama_cloud_services/src/beta/agent/types.ts
@@ -87,8 +87,8 @@ export interface ExtractedData<T = unknown> {
 export interface TypedAgentData<T = unknown> {
   /** The unique ID of the agent data record. */
   id: string;
-  /** The ID of the agent that created the data. */
-  agentUrlId: string;
+  /** The deployment name of the agent that created the data. */
+  deploymentName: string;
   /** The collection of the agent data. */
   collection?: string;
   /** The data of the agent data. Usually an ExtractedData&lt;SomeOtherType&gt; */

--- a/ts/llama_cloud_services/src/client/schemas.gen.ts
+++ b/ts/llama_cloud_services/src/client/schemas.gen.ts
@@ -191,9 +191,9 @@ export const AgentDataSchema = {
       ],
       title: "Id",
     },
-    agent_slug: {
+    deployment_name: {
       type: "string",
-      title: "Agent Slug",
+      title: "Deployment Name",
     },
     collection: {
       type: "string",
@@ -231,16 +231,16 @@ export const AgentDataSchema = {
     },
   },
   type: "object",
-  required: ["agent_slug", "data"],
+  required: ["deployment_name", "data"],
   title: "AgentData",
   description: "API Result for a single agent data item",
 } as const;
 
 export const AgentDataCreateSchema = {
   properties: {
-    agent_slug: {
+    deployment_name: {
       type: "string",
-      title: "Agent Slug",
+      title: "Deployment Name",
     },
     collection: {
       type: "string",
@@ -254,7 +254,7 @@ export const AgentDataCreateSchema = {
     },
   },
   type: "object",
-  required: ["agent_slug", "data"],
+  required: ["deployment_name", "data"],
   title: "AgentDataCreate",
   description: "API request model for creating agent data",
 } as const;
@@ -302,9 +302,9 @@ export const AgentDeploymentSummarySchema = {
       title: "Project Id",
       description: "Project ID",
     },
-    agent_slug: {
+    deployment_name: {
       type: "string",
-      title: "Agent Slug",
+      title: "Deployment Name",
       description: "readable ID of the deployed app",
     },
     thumbnail_url: {
@@ -346,7 +346,7 @@ export const AgentDeploymentSummarySchema = {
   required: [
     "id",
     "project_id",
-    "agent_slug",
+    "deployment_name",
     "base_url",
     "display_name",
     "created_at",
@@ -449,10 +449,10 @@ export const AggregateRequestSchema = {
       description:
         "A comma-separated list of fields to order by, sorted in ascending order. Use 'field_name desc' to specify descending order.",
     },
-    agent_slug: {
+    deployment_name: {
       type: "string",
-      title: "Agent Slug",
-      description: "The agent deployment's agent_slug to aggregate data for",
+      title: "Deployment Name",
+      description: "The agent deployment's deployment_name to aggregate data for",
     },
     collection: {
       type: "string",
@@ -521,7 +521,7 @@ export const AggregateRequestSchema = {
     },
   },
   type: "object",
-  required: ["agent_slug"],
+  required: ["deployment_name"],
   title: "AggregateRequest",
   description: "API request body for aggregating agent data",
 } as const;
@@ -17515,10 +17515,10 @@ export const SearchRequestSchema = {
       description:
         "A comma-separated list of fields to order by, sorted in ascending order. Use 'field_name desc' to specify descending order.",
     },
-    agent_slug: {
+    deployment_name: {
       type: "string",
-      title: "Agent Slug",
-      description: "The agent deployment's agent_slug to search within",
+      title: "Deployment Name",
+      description: "The agent deployment's deployment_name to search within",
     },
     collection: {
       type: "string",
@@ -17551,7 +17551,7 @@ export const SearchRequestSchema = {
     },
   },
   type: "object",
-  required: ["agent_slug"],
+  required: ["deployment_name"],
   title: "SearchRequest",
   description: "API request body for searching agent data",
 } as const;

--- a/ts/llama_cloud_services/src/client/schemas.gen.ts
+++ b/ts/llama_cloud_services/src/client/schemas.gen.ts
@@ -452,7 +452,8 @@ export const AggregateRequestSchema = {
     deployment_name: {
       type: "string",
       title: "Deployment Name",
-      description: "The agent deployment's deployment_name to aggregate data for",
+      description:
+        "The agent deployment's deployment_name to aggregate data for",
     },
     collection: {
       type: "string",

--- a/ts/llama_cloud_services/src/client/schemas.gen.ts
+++ b/ts/llama_cloud_services/src/client/schemas.gen.ts
@@ -59,6 +59,10 @@ export const APIKeySchema = {
       ],
       title: "Project Id",
     },
+    key_type: {
+      $ref: "#/components/schemas/APIKeyType",
+      default: "user",
+    },
     user_id: {
       type: "string",
       title: "User Id",
@@ -102,31 +106,63 @@ export const APIKeyCreateSchema = {
       title: "Project Id",
       description: "The project ID to associate with the API key.",
     },
+    key_type: {
+      $ref: "#/components/schemas/APIKeyType",
+      default: "user",
+    },
   },
   type: "object",
   title: "APIKeyCreate",
   description: "Schema for creating an API key.",
 } as const;
 
-export const APIKeyUpdateSchema = {
+export const APIKeyQueryResponseSchema = {
   properties: {
-    name: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/APIKey",
+      },
+      type: "array",
+      title: "Items",
+      description: "The list of items.",
+    },
+    next_page_token: {
       anyOf: [
         {
           type: "string",
-          maxLength: 3000,
-          minLength: 0,
         },
         {
           type: "null",
         },
       ],
-      title: "Name",
+      title: "Next Page Token",
+      description:
+        "A token, which can be sent as page_token to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+    },
+    total_size: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Size",
+      description:
+        "The total number of items available. This is only populated when specifically requested. The value may be an estimate and can be used for display purposes only.",
     },
   },
   type: "object",
-  title: "APIKeyUpdate",
-  description: "Schema for updating an API key.",
+  required: ["items"],
+  title: "APIKeyQueryResponse",
+  description: "Response schema for paginated API key queries.",
+} as const;
+
+export const APIKeyTypeSchema = {
+  type: "string",
+  enum: ["user", "agent"],
+  title: "APIKeyType",
 } as const;
 
 export const AdvancedModeTransformConfigSchema = {
@@ -305,7 +341,7 @@ export const AgentDeploymentSummarySchema = {
     deployment_name: {
       type: "string",
       title: "Deployment Name",
-      description: "readable ID of the deployed app",
+      description: "Identifier of the deployed app",
     },
     thumbnail_url: {
       anyOf: [
@@ -324,11 +360,6 @@ export const AgentDeploymentSummarySchema = {
       title: "Base Url",
       description: "Base URL of the deployed app",
     },
-    display_name: {
-      type: "string",
-      title: "Display Name",
-      description: "Display name of the deployed app",
-    },
     created_at: {
       type: "string",
       format: "date-time",
@@ -341,6 +372,19 @@ export const AgentDeploymentSummarySchema = {
       title: "Updated At",
       description: "Timestamp when the app deployment was last updated",
     },
+    api_key_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Api Key Id",
+      description: "API key ID",
+    },
   },
   type: "object",
   required: [
@@ -348,7 +392,6 @@ export const AgentDeploymentSummarySchema = {
     "project_id",
     "deployment_name",
     "base_url",
-    "display_name",
     "created_at",
     "updated_at",
   ],
@@ -452,8 +495,7 @@ export const AggregateRequestSchema = {
     deployment_name: {
       type: "string",
       title: "Deployment Name",
-      description:
-        "The agent deployment's deployment_name to aggregate data for",
+      description: "The agent deployment's name to aggregate data for",
     },
     collection: {
       type: "string",
@@ -508,6 +550,7 @@ export const AggregateRequestSchema = {
       anyOf: [
         {
           type: "integer",
+          maximum: 1000,
           minimum: 0,
         },
         {
@@ -518,7 +561,6 @@ export const AggregateRequestSchema = {
       description:
         "The offset to start from. If not provided, the first page is returned",
       default: 0,
-      lte: 1000,
     },
   },
   type: "object",
@@ -550,70 +592,6 @@ export const AppChatInputParamsSchema = {
       ],
     },
   ],
-} as const;
-
-export const AudioBlockSchema = {
-  properties: {
-    block_type: {
-      type: "string",
-      const: "audio",
-      title: "Block Type",
-      default: "audio",
-    },
-    audio: {
-      anyOf: [
-        {
-          type: "string",
-          format: "binary",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Audio",
-    },
-    path: {
-      anyOf: [
-        {
-          type: "string",
-          format: "file-path",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Path",
-    },
-    url: {
-      anyOf: [
-        {
-          type: "string",
-          minLength: 1,
-          format: "uri",
-        },
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Url",
-    },
-    format: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Format",
-    },
-  },
-  type: "object",
-  title: "AudioBlock",
 } as const;
 
 export const AutoTransformConfigSchema = {
@@ -1491,135 +1469,6 @@ export const BillingPeriodSchema = {
   title: "BillingPeriod",
 } as const;
 
-export const Body_classify_documents_api_v1_classifier_classify_postSchema = {
-  properties: {
-    rules_json: {
-      type: "string",
-      title: "Rules Json",
-      description: "JSON string containing classifier rules",
-    },
-    files: {
-      anyOf: [
-        {
-          items: {
-            type: "string",
-            format: "binary",
-          },
-          type: "array",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Files",
-    },
-    file_ids: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "File Ids",
-      description: "Comma-separated list of existing file IDs",
-    },
-    matching_threshold: {
-      anyOf: [
-        {
-          type: "number",
-          maximum: 0.99,
-          minimum: 0.1,
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Matching Threshold",
-      description:
-        "Minimum confidence threshold for acceptable matches (0.1-0.99, default: 0.6)",
-      default: 0.6,
-    },
-    enable_metadata_heuristic: {
-      anyOf: [
-        {
-          type: "boolean",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Enable Metadata Heuristic",
-      description:
-        "Enable metadata-based features (document filtering + content classification, default: true)",
-      default: true,
-    },
-  },
-  type: "object",
-  required: ["rules_json"],
-  title: "Body_classify_documents_api_v1_classifier_classify_post",
-} as const;
-
-export const Body_create_report_api_v1_reports__postSchema = {
-  properties: {
-    name: {
-      type: "string",
-      title: "Name",
-    },
-    template_text: {
-      type: "string",
-      title: "Template Text",
-    },
-    template_instructions: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Template Instructions",
-    },
-    existing_retriever_id: {
-      anyOf: [
-        {
-          type: "string",
-          format: "uuid",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Existing Retriever Id",
-    },
-    files: {
-      items: {
-        type: "string",
-        format: "binary",
-      },
-      type: "array",
-      title: "Files",
-    },
-    template_file: {
-      anyOf: [
-        {
-          type: "string",
-          format: "binary",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Template File",
-    },
-  },
-  type: "object",
-  required: ["name", "files"],
-  title: "Body_create_report_api_v1_reports__post",
-} as const;
-
 export const Body_import_pipeline_metadata_api_v1_pipelines__pipeline_id__metadata_putSchema =
   {
     properties: {
@@ -1775,6 +1624,11 @@ export const Body_screenshot_api_parsing_screenshot_postSchema = {
       title: "Webhook Url",
       default: "",
     },
+    webhook_configurations: {
+      type: "string",
+      title: "Webhook Configurations",
+      default: "",
+    },
     job_timeout_in_seconds: {
       type: "number",
       title: "Job Timeout In Seconds",
@@ -1859,6 +1713,11 @@ export const Body_screenshot_api_v1_parsing_screenshot_postSchema = {
     webhook_url: {
       type: "string",
       title: "Webhook Url",
+      default: "",
+    },
+    webhook_configurations: {
+      type: "string",
+      title: "Webhook Configurations",
       default: "",
     },
     job_timeout_in_seconds: {
@@ -2007,6 +1866,36 @@ export const Body_upload_file_api_parsing_upload_postSchema = {
       title: "Html Make All Elements Visible",
       default: false,
     },
+    layout_aware: {
+      type: "boolean",
+      title: "Layout Aware",
+      default: false,
+    },
+    specialized_chart_parsing_agentic: {
+      type: "boolean",
+      title: "Specialized Chart Parsing Agentic",
+      default: false,
+    },
+    specialized_chart_parsing_plus: {
+      type: "boolean",
+      title: "Specialized Chart Parsing Plus",
+      default: false,
+    },
+    specialized_chart_parsing_efficient: {
+      type: "boolean",
+      title: "Specialized Chart Parsing Efficient",
+      default: false,
+    },
+    specialized_image_parsing: {
+      type: "boolean",
+      title: "Specialized Image Parsing",
+      default: false,
+    },
+    precise_bounding_box: {
+      type: "boolean",
+      title: "Precise Bounding Box",
+      default: false,
+    },
     html_remove_fixed_elements: {
       type: "boolean",
       title: "Html Remove Fixed Elements",
@@ -2108,6 +1997,11 @@ export const Body_upload_file_api_parsing_upload_postSchema = {
       title: "Preserve Layout Alignment Across Pages",
       default: false,
     },
+    preserve_very_small_text: {
+      type: "boolean",
+      title: "Preserve Very Small Text",
+      default: false,
+    },
     skip_diagonal_text: {
       type: "boolean",
       title: "Skip Diagonal Text",
@@ -2117,6 +2011,16 @@ export const Body_upload_file_api_parsing_upload_postSchema = {
       type: "boolean",
       title: "Spreadsheet Extract Sub Tables",
       default: true,
+    },
+    spreadsheet_force_formula_computation: {
+      type: "boolean",
+      title: "Spreadsheet Force Formula Computation",
+      default: false,
+    },
+    inline_images_in_markdown: {
+      type: "boolean",
+      title: "Inline Images In Markdown",
+      default: false,
     },
     structured_output: {
       type: "boolean",
@@ -2157,6 +2061,11 @@ export const Body_upload_file_api_parsing_upload_postSchema = {
     webhook_url: {
       type: "string",
       title: "Webhook Url",
+      default: "",
+    },
+    webhook_configurations: {
+      type: "string",
+      title: "Webhook Configurations",
       default: "",
     },
     preset: {
@@ -2495,6 +2404,36 @@ export const Body_upload_file_api_v1_parsing_upload_postSchema = {
       title: "Html Make All Elements Visible",
       default: false,
     },
+    layout_aware: {
+      type: "boolean",
+      title: "Layout Aware",
+      default: false,
+    },
+    specialized_chart_parsing_agentic: {
+      type: "boolean",
+      title: "Specialized Chart Parsing Agentic",
+      default: false,
+    },
+    specialized_chart_parsing_plus: {
+      type: "boolean",
+      title: "Specialized Chart Parsing Plus",
+      default: false,
+    },
+    specialized_chart_parsing_efficient: {
+      type: "boolean",
+      title: "Specialized Chart Parsing Efficient",
+      default: false,
+    },
+    specialized_image_parsing: {
+      type: "boolean",
+      title: "Specialized Image Parsing",
+      default: false,
+    },
+    precise_bounding_box: {
+      type: "boolean",
+      title: "Precise Bounding Box",
+      default: false,
+    },
     html_remove_fixed_elements: {
       type: "boolean",
       title: "Html Remove Fixed Elements",
@@ -2596,6 +2535,11 @@ export const Body_upload_file_api_v1_parsing_upload_postSchema = {
       title: "Preserve Layout Alignment Across Pages",
       default: false,
     },
+    preserve_very_small_text: {
+      type: "boolean",
+      title: "Preserve Very Small Text",
+      default: false,
+    },
     skip_diagonal_text: {
       type: "boolean",
       title: "Skip Diagonal Text",
@@ -2605,6 +2549,16 @@ export const Body_upload_file_api_v1_parsing_upload_postSchema = {
       type: "boolean",
       title: "Spreadsheet Extract Sub Tables",
       default: true,
+    },
+    spreadsheet_force_formula_computation: {
+      type: "boolean",
+      title: "Spreadsheet Force Formula Computation",
+      default: false,
+    },
+    inline_images_in_markdown: {
+      type: "boolean",
+      title: "Inline Images In Markdown",
+      default: false,
     },
     structured_output: {
       type: "boolean",
@@ -2645,6 +2599,11 @@ export const Body_upload_file_api_v1_parsing_upload_postSchema = {
     webhook_url: {
       type: "string",
       title: "Webhook Url",
+      default: "",
+    },
+    webhook_configurations: {
+      type: "string",
+      title: "Webhook Configurations",
       default: "",
     },
     preset: {
@@ -2835,6 +2794,30 @@ export const Body_upload_file_api_v1_parsing_upload_postSchema = {
   },
   type: "object",
   title: "Body_upload_file_api_v1_parsing_upload_post",
+} as const;
+
+export const Body_upload_file_v2_api_v2alpha1_parse_upload_postSchema = {
+  properties: {
+    configuration: {
+      type: "string",
+      title: "Configuration",
+    },
+    file: {
+      anyOf: [
+        {
+          type: "string",
+          format: "binary",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "File",
+    },
+  },
+  type: "object",
+  required: ["configuration"],
+  title: "Body_upload_file_v2_api_v2alpha1_parse_upload_post",
 } as const;
 
 export const BoxAuthMechanismSchema = {
@@ -3142,34 +3125,31 @@ export const ChatInputParamsSchema = {
   title: "ChatInputParams",
 } as const;
 
-export const ChunkModeSchema = {
-  type: "string",
-  enum: ["PAGE", "DOCUMENT", "SECTION", "GROUPED_PAGES"],
-  title: "ChunkMode",
-} as const;
-
-export const ClassificationResultSchema = {
+export const ChatMessageSchema = {
   properties: {
-    file_id: {
+    id: {
       type: "string",
       format: "uuid",
-      title: "File Id",
-      description: "The ID of the classified file",
+      title: "Id",
     },
-    type: {
-      type: "string",
-      title: "Type",
-      description: "The assigned document type ('unknown' if no rules matched)",
-      examples: ["invoice", "receipt", "contract", "unknown"],
+    index: {
+      type: "integer",
+      title: "Index",
+      description: "The index of the message in the chat.",
     },
-    confidence: {
-      type: "number",
-      maximum: 1,
-      minimum: 0,
-      title: "Confidence",
-      description: "Confidence score of the classification (0.0-1.0)",
+    annotations: {
+      items: {
+        $ref: "#/components/schemas/MessageAnnotation",
+      },
+      type: "array",
+      title: "Annotations",
+      description: "Retrieval annotations for the message.",
     },
-    matched_rule: {
+    role: {
+      $ref: "#/components/schemas/MessageRole",
+      description: "The role of the message.",
+    },
+    content: {
       anyOf: [
         {
           type: "string",
@@ -3178,29 +3158,217 @@ export const ClassificationResultSchema = {
           type: "null",
         },
       ],
-      title: "Matched Rule",
+      title: "Content",
+      description: "Text content of the generation",
+    },
+    additional_kwargs: {
+      additionalProperties: {
+        type: "string",
+      },
+      type: "object",
+      title: "Additional Kwargs",
+      description: "Additional arguments passed to the model",
+    },
+    class_name: {
+      type: "string",
+      title: "Class Name",
+      default: "base_component",
+    },
+  },
+  type: "object",
+  required: ["id", "index", "role"],
+  title: "ChatMessage",
+} as const;
+
+export const ChunkModeSchema = {
+  type: "string",
+  enum: ["PAGE", "DOCUMENT", "SECTION", "GROUPED_PAGES"],
+  title: "ChunkMode",
+} as const;
+
+export const ClassificationResultSchema = {
+  properties: {
+    reasoning: {
+      type: "string",
+      title: "Reasoning",
       description:
-        "Description of the rule that matched, or method used (e.g., 'auto: filename contains invoice')",
+        "Step-by-step explanation of why this classification was chosen and the confidence score assigned",
+    },
+    confidence: {
+      type: "number",
+      maximum: 1,
+      minimum: 0,
+      title: "Confidence",
+      description: "Confidence score of the classification (0.0-1.0)",
+    },
+    type: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Type",
+      description: "The document type that best matches, or null if no match.",
+    },
+  },
+  type: "object",
+  required: ["reasoning", "confidence", "type"],
+  title: "ClassificationResult",
+  description: "Result of classifying a single file.",
+} as const;
+
+export const ClassifierRuleSchema = {
+  properties: {
+    type: {
+      type: "string",
+      maxLength: 50,
+      minLength: 1,
+      title: "Type",
+      description:
+        "The document type to assign when this rule matches (e.g., 'invoice', 'receipt', 'contract')",
+      examples: ["invoice", "receipt", "contract", "report", "proposal"],
+    },
+    description: {
+      type: "string",
+      maxLength: 500,
+      minLength: 10,
+      title: "Description",
+      description:
+        "Natural language description of what to classify. Be specific about the content characteristics that identify this document type.",
       examples: [
-        "contains invoice number, line items, and total",
-        "auto: filename contains 'invoice'",
-        null,
+        "contains invoice number, line items, and total amount",
+        "purchase receipt with transaction info and merchant details",
+        "legal contract with terms, conditions, and signatures",
       ],
     },
   },
   type: "object",
-  required: ["file_id", "type", "confidence", "matched_rule"],
-  title: "ClassificationResult",
-  description: `Result of classifying a single file.
+  required: ["type", "description"],
+  title: "ClassifierRule",
+  description: `A rule for classifying documents - v0 simplified version.
 
-Contains the classification outcome with confidence score and matched rule info.`,
+This represents a single classification rule that will be applied to documents.
+All rules are content-based and use natural language descriptions.`,
 } as const;
 
-export const ClassifyResponseSchema = {
+export const ClassifyJobSchema = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+      description: "Unique identifier",
+    },
+    created_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Created At",
+      description: "Creation datetime",
+    },
+    updated_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Updated At",
+      description: "Update datetime",
+    },
+    rules: {
+      items: {
+        $ref: "#/components/schemas/ClassifierRule",
+      },
+      type: "array",
+      minItems: 1,
+      title: "Rules",
+      description: "The rules to classify the files",
+    },
+    user_id: {
+      type: "string",
+      title: "User Id",
+      description: "The ID of the user",
+    },
+    project_id: {
+      type: "string",
+      format: "uuid",
+      title: "Project Id",
+      description: "The ID of the project",
+    },
+    status: {
+      $ref: "#/components/schemas/StatusEnum",
+      description: "The status of the classify job",
+    },
+    parsing_configuration: {
+      $ref: "#/components/schemas/ClassifyParsingConfiguration",
+      description: "The configuration for the parsing job",
+      default: {
+        lang: "en",
+        max_pages: 5,
+      },
+    },
+  },
+  type: "object",
+  required: ["id", "rules", "user_id", "project_id", "status"],
+  title: "ClassifyJob",
+  description: "A classify job.",
+} as const;
+
+export const ClassifyJobCreateSchema = {
+  properties: {
+    rules: {
+      items: {
+        $ref: "#/components/schemas/ClassifierRule",
+      },
+      type: "array",
+      minItems: 1,
+      title: "Rules",
+      description: "The rules to classify the files",
+    },
+    file_ids: {
+      items: {
+        type: "string",
+        format: "uuid",
+      },
+      type: "array",
+      maxItems: 500,
+      minItems: 1,
+      title: "File Ids",
+      description: "The IDs of the files to classify",
+    },
+    parsing_configuration: {
+      $ref: "#/components/schemas/ClassifyParsingConfiguration",
+      description: "The configuration for the parsing job",
+      default: {
+        lang: "en",
+        max_pages: 5,
+      },
+    },
+  },
+  type: "object",
+  required: ["rules", "file_ids"],
+  title: "ClassifyJobCreate",
+  description: "A classify job.",
+} as const;
+
+export const ClassifyJobResultsSchema = {
   properties: {
     items: {
       items: {
-        $ref: "#/components/schemas/ClassificationResult",
+        $ref: "#/components/schemas/FileClassification",
       },
       type: "array",
       title: "Items",
@@ -3232,19 +3400,120 @@ export const ClassifyResponseSchema = {
       description:
         "The total number of items available. This is only populated when specifically requested. The value may be an estimate and can be used for display purposes only.",
     },
-    unknown_count: {
-      type: "integer",
-      minimum: 0,
-      title: "Unknown Count",
-      description: "Number of files that couldn't be classified",
+  },
+  type: "object",
+  required: ["items"],
+  title: "ClassifyJobResults",
+  description:
+    "Response model for the classify endpoint following AIP-132 pagination standard.",
+} as const;
+
+export const ClassifyParsingConfigurationSchema = {
+  properties: {
+    lang: {
+      $ref: "#/components/schemas/ParserLanguages",
+      description: "The language to parse the files in",
+      default: "en",
+    },
+    max_pages: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Pages",
+      description: "The maximum number of pages to parse",
+      default: 5,
+    },
+    target_pages: {
+      anyOf: [
+        {
+          items: {
+            type: "integer",
+          },
+          type: "array",
+          minItems: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Target Pages",
+      description:
+        "The pages to target for parsing (0-indexed, so first page is at 0)",
     },
   },
   type: "object",
-  required: ["items", "unknown_count"],
-  title: "ClassifyResponse",
-  description: `Response model for the classify endpoint following AIP-132 pagination standard.
+  title: "ClassifyParsingConfiguration",
+  description: "Parsing configuration for a classify job.",
+} as const;
 
-Contains classification results with pagination support and summary statistics.`,
+export const CloudAstraDBVectorStoreSchema = {
+  properties: {
+    supports_nested_metadata_filters: {
+      type: "boolean",
+      const: true,
+      title: "Supports Nested Metadata Filters",
+      default: true,
+    },
+    token: {
+      type: "string",
+      format: "password",
+      title: "Token",
+      description: "The Astra DB Application Token to use",
+      writeOnly: true,
+    },
+    api_endpoint: {
+      type: "string",
+      title: "Api Endpoint",
+      description: "The Astra DB JSON API endpoint for your database",
+    },
+    collection_name: {
+      type: "string",
+      title: "Collection Name",
+      description:
+        "Collection name to use. If not existing, it will be created",
+    },
+    embedding_dimension: {
+      type: "integer",
+      title: "Embedding Dimension",
+      description: "Length of the embedding vectors in use",
+    },
+    keyspace: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Keyspace",
+      description: "The keyspace to use. If not provided, 'default_keyspace'",
+    },
+    class_name: {
+      type: "string",
+      title: "Class Name",
+      default: "CloudAstraDBVectorStore",
+    },
+  },
+  type: "object",
+  required: ["token", "api_endpoint", "collection_name", "embedding_dimension"],
+  title: "CloudAstraDBVectorStore",
+  description: `Cloud AstraDB Vector Store.
+
+This class is used to store the configuration for an AstraDB vector store, so that it can be
+created and used in LlamaCloud.
+
+Args:
+    token (str): The Astra DB Application Token to use.
+    api_endpoint (str): The Astra DB JSON API endpoint for your database.
+    collection_name (str): Collection name to use. If not existing, it will be created.
+    embedding_dimension (int): Length of the embedding vectors in use.
+    keyspace (optional[str]): The keyspace to use. If not provided, 'default_keyspace'`,
 } as const;
 
 export const CloudAzStorageBlobDataSourceSchema = {
@@ -3677,7 +3946,18 @@ export const CloudConfluenceDataSourceSchema = {
       type: "boolean",
       title: "Keep Markdown Format",
       description: "Whether to keep the markdown format.",
-      default: true,
+    },
+    failure_handling: {
+      $ref: "#/components/schemas/FailureHandlingConfig",
+      description: `Configuration for handling failures during processing. Key-value object controlling failure handling behaviors.
+
+Example:
+{
+  "skip_list_failures": true
+}
+
+Currently supports:
+- skip_list_failures: Skip failed batches/lists and continue processing`,
     },
     class_name: {
       type: "string",
@@ -3883,6 +4163,134 @@ export const CloudJiraDataSourceSchema = {
   required: ["authentication_mechanism", "query"],
   title: "CloudJiraDataSource",
   description: "Cloud Jira Data Source integrating JiraReader.",
+} as const;
+
+export const CloudJiraDataSourceV2Schema = {
+  properties: {
+    supports_access_control: {
+      type: "boolean",
+      title: "Supports Access Control",
+      default: false,
+    },
+    email: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Email",
+      description: "The email address to use for authentication.",
+    },
+    api_token: {
+      anyOf: [
+        {
+          type: "string",
+          format: "password",
+          writeOnly: true,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Api Token",
+      description:
+        "The API Access Token used for Basic, PAT and OAuth2 authentication.",
+    },
+    server_url: {
+      type: "string",
+      title: "Server Url",
+      description: "The server url for Jira Cloud.",
+    },
+    cloud_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Cloud Id",
+      description: "The cloud ID, used in case of OAuth2.",
+    },
+    authentication_mechanism: {
+      type: "string",
+      title: "Authentication Mechanism",
+      description: "Type of Authentication for connecting to Jira APIs.",
+    },
+    api_version: {
+      type: "string",
+      enum: ["2", "3"],
+      title: "Api Version",
+      description:
+        "Jira REST API version to use (2 or 3). 3 supports Atlassian Document Format (ADF).",
+      default: "2",
+    },
+    query: {
+      type: "string",
+      title: "Query",
+      description: "JQL (Jira Query Language) query to search.",
+    },
+    fields: {
+      anyOf: [
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Fields",
+      description:
+        "List of fields to retrieve from Jira. If None, retrieves all fields.",
+    },
+    expand: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Expand",
+      description: "Fields to expand in the response.",
+    },
+    requests_per_minute: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Requests Per Minute",
+      description: "Rate limit for Jira API requests per minute.",
+    },
+    get_permissions: {
+      type: "boolean",
+      title: "Get Permissions",
+      description:
+        "Whether to fetch project role permissions and issue-level security",
+      default: true,
+    },
+    class_name: {
+      type: "string",
+      title: "Class Name",
+      default: "CloudJiraDataSourceV2",
+    },
+  },
+  type: "object",
+  required: ["server_url", "authentication_mechanism", "query"],
+  title: "CloudJiraDataSourceV2",
+  description: "Cloud Jira Data Source integrating JiraReaderV2.",
 } as const;
 
 export const CloudMilvusVectorStoreSchema = {
@@ -4948,6 +5356,7 @@ export const ConfigurableDataSinkNamesSchema = {
     "AZUREAI_SEARCH",
     "MONGODB_ATLAS",
     "MILVUS",
+    "ASTRA_DB",
   ],
   title: "ConfigurableDataSinkNames",
 } as const;
@@ -4964,6 +5373,7 @@ export const ConfigurableDataSourceNamesSchema = {
     "NOTION_PAGE",
     "CONFLUENCE",
     "JIRA",
+    "JIRA_V2",
     "BOX",
   ],
   title: "ConfigurableDataSourceNames",
@@ -5006,6 +5416,81 @@ export const CreditTypeSchema = {
   type: "object",
   required: ["id", "name"],
   title: "CreditType",
+} as const;
+
+export const CustomClaimsSchema = {
+  properties: {
+    allowed_org_creation: {
+      type: "boolean",
+      title: "Allowed Org Creation",
+      description: "Whether the user is allowed to create organizations.",
+      default: false,
+    },
+    max_jobs_in_execution_per_job_type: {
+      type: "integer",
+      title: "Max Jobs In Execution Per Job Type",
+      description:
+        "The maximum number of jobs the user can have in execution per job type.",
+      default: 10,
+    },
+    max_document_ingestion_jobs_in_execution: {
+      type: "integer",
+      title: "Max Document Ingestion Jobs In Execution",
+      description:
+        "The maximum number of document ingestion jobs the user can have in execution.",
+      default: 2,
+    },
+    max_metadata_update_jobs_in_execution: {
+      type: "integer",
+      title: "Max Metadata Update Jobs In Execution",
+      description:
+        "The maximum number of metadata update jobs the user can have in execution.",
+      default: 10,
+    },
+    extraction_test_user: {
+      type: "boolean",
+      title: "Extraction Test User",
+      description:
+        "Whether the user is a test user for extraction. This will include additional debug metadata and access to test endpoints.",
+      default: false,
+    },
+    allowed_report: {
+      type: "boolean",
+      title: "Allowed Report",
+      description:
+        "Whether the user is allowed to access llama-report generation.",
+      default: false,
+    },
+    allowed_app: {
+      type: "boolean",
+      title: "Allowed App",
+      description: "Whether the user is allowed to access the app.",
+      default: false,
+    },
+    allowed_classify: {
+      type: "boolean",
+      title: "Allowed Classify",
+      description:
+        "Whether the user is allowed to access the classifier feature.",
+      default: true,
+    },
+    api_datasource_access: {
+      type: "boolean",
+      title: "Api Datasource Access",
+      description: "Whether the user is allowed to access API data sources.",
+      default: false,
+    },
+    allow_org_deletion: {
+      type: "boolean",
+      title: "Allow Org Deletion",
+      description: "Whether the user is allowed to delete organizations.",
+      default: false,
+    },
+  },
+  type: "object",
+  title: "CustomClaims",
+  description: `Custom claims that dictate various limits or allowed behaviors.
+Currently these claims reside at a per user level. Claims may expand to a per organization level or project in the future.`,
 } as const;
 
 export const CustomerPortalSessionCreatePayloadSchema = {
@@ -5088,6 +5573,9 @@ export const DataSinkSchema = {
         {
           $ref: "#/components/schemas/CloudMilvusVectorStore",
         },
+        {
+          $ref: "#/components/schemas/CloudAstraDBVectorStore",
+        },
       ],
       title: "DataSinkCreateComponent",
       description: "Component that implements the data sink",
@@ -5137,6 +5625,9 @@ export const DataSinkCreateSchema = {
         },
         {
           $ref: "#/components/schemas/CloudMilvusVectorStore",
+        },
+        {
+          $ref: "#/components/schemas/CloudAstraDBVectorStore",
         },
       ],
       title: "DataSinkCreateComponent",
@@ -5189,6 +5680,9 @@ export const DataSinkUpdateSchema = {
         },
         {
           $ref: "#/components/schemas/CloudMilvusVectorStore",
+        },
+        {
+          $ref: "#/components/schemas/CloudAstraDBVectorStore",
         },
         {
           type: "null",
@@ -5317,6 +5811,9 @@ export const DataSourceSchema = {
           $ref: "#/components/schemas/CloudJiraDataSource",
         },
         {
+          $ref: "#/components/schemas/CloudJiraDataSourceV2",
+        },
+        {
           $ref: "#/components/schemas/CloudBoxDataSource",
         },
       ],
@@ -5427,6 +5924,9 @@ export const DataSourceCreateSchema = {
           $ref: "#/components/schemas/CloudJiraDataSource",
         },
         {
+          $ref: "#/components/schemas/CloudJiraDataSourceV2",
+        },
+        {
           $ref: "#/components/schemas/CloudBoxDataSource",
         },
       ],
@@ -5446,6 +5946,7 @@ export const DataSourceReaderVersionMetadataSchema = {
       anyOf: [
         {
           type: "string",
+          enum: ["1.0", "2.0", "2.1"],
         },
         {
           type: "null",
@@ -5545,6 +6046,9 @@ export const DataSourceUpdateSchema = {
         },
         {
           $ref: "#/components/schemas/CloudJiraDataSource",
+        },
+        {
+          $ref: "#/components/schemas/CloudJiraDataSourceV2",
         },
         {
           $ref: "#/components/schemas/CloudBoxDataSource",
@@ -5754,79 +6258,6 @@ export const DirectRetrievalParamsSchema = {
   title: "DirectRetrievalParams",
 } as const;
 
-export const DocumentBlockSchema = {
-  properties: {
-    block_type: {
-      type: "string",
-      const: "document",
-      title: "Block Type",
-      default: "document",
-    },
-    data: {
-      anyOf: [
-        {
-          type: "string",
-          format: "binary",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Data",
-    },
-    path: {
-      anyOf: [
-        {
-          type: "string",
-          format: "file-path",
-        },
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Path",
-    },
-    url: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Url",
-    },
-    title: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Title",
-    },
-    document_mimetype: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Document Mimetype",
-    },
-  },
-  type: "object",
-  title: "DocumentBlock",
-} as const;
-
 export const DocumentChunkModeSchema = {
   type: "string",
   enum: ["PAGE", "SECTION"],
@@ -5941,60 +6372,6 @@ export const DocumentIngestionJobParamsSchema = {
   type: "object",
   title: "DocumentIngestionJobParams",
   description: "Schema for the parameters of a document ingestion job.",
-} as const;
-
-export const EditSuggestionSchema = {
-  properties: {
-    justification: {
-      type: "string",
-      title: "Justification",
-    },
-    blocks: {
-      items: {
-        anyOf: [
-          {
-            $ref: "#/components/schemas/ReportBlock",
-          },
-          {
-            $ref: "#/components/schemas/ReportPlanBlock",
-          },
-        ],
-      },
-      type: "array",
-      title: "Blocks",
-    },
-    removed_indices: {
-      items: {
-        type: "integer",
-      },
-      type: "array",
-      title: "Removed Indices",
-    },
-  },
-  type: "object",
-  required: ["justification", "blocks"],
-  title: "EditSuggestion",
-  description: "A suggestion for an edit to a report.",
-} as const;
-
-export const EditSuggestionCreateSchema = {
-  properties: {
-    user_query: {
-      type: "string",
-      title: "User Query",
-    },
-    chat_history: {
-      items: {
-        $ref: "#/components/schemas/llama_index__core__base__llms__types__ChatMessage",
-      },
-      type: "array",
-      title: "Chat History",
-    },
-  },
-  type: "object",
-  required: ["user_query", "chat_history"],
-  title: "EditSuggestionCreate",
-  description: "A request to suggest edits for a report.",
 } as const;
 
 export const ElementSegmentationConfigSchema = {
@@ -6306,6 +6683,20 @@ export const ExtractAgentSchema = {
       $ref: "#/components/schemas/ExtractConfig",
       description: "The configuration parameters for the extraction agent.",
     },
+    custom_configuration: {
+      anyOf: [
+        {
+          type: "string",
+          const: "default",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Custom Configuration",
+      description:
+        "Custom configuration type for the extraction agent. Currently supports 'default'.",
+    },
     created_at: {
       anyOf: [
         {
@@ -6473,13 +6864,39 @@ export const ExtractConfigSchema = {
     },
     extraction_mode: {
       $ref: "#/components/schemas/ExtractMode",
-      description: "The extraction mode specified.",
+      description:
+        "The extraction mode specified (FAST, BALANCED, MULTIMODAL, PREMIUM).",
       default: "BALANCED",
+    },
+    parse_model: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/PublicModelName",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description:
+        "The parse model to use for document parsing. If not provided, uses the default for the extraction mode.",
+    },
+    extract_model: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/ExtractModels",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description:
+        "The extract model to use for data extraction. If not provided, uses the default for the extraction mode.",
     },
     multimodal_fast_mode: {
       type: "boolean",
       title: "Multimodal Fast Mode",
-      description: "Whether to use fast mode for multimodal extraction.",
+      description:
+        "DEPRECATED: Whether to use fast mode for multimodal extraction.",
       default: false,
     },
     system_prompt: {
@@ -6506,16 +6923,41 @@ export const ExtractConfigSchema = {
       description: "Whether to cite sources for the extraction.",
       default: false,
     },
+    confidence_scores: {
+      type: "boolean",
+      title: "Confidence Scores",
+      description: "Whether to fetch confidence scores for the extraction.",
+      default: false,
+    },
     chunk_mode: {
       $ref: "#/components/schemas/DocumentChunkMode",
       description: "The mode to use for chunking the document.",
       default: "PAGE",
+    },
+    high_resolution_mode: {
+      type: "boolean",
+      title: "High Resolution Mode",
+      description: "Whether to use high resolution mode for the extraction.",
+      default: false,
     },
     invalidate_cache: {
       type: "boolean",
       title: "Invalidate Cache",
       description: "Whether to invalidate the cache for the extraction.",
       default: false,
+    },
+    page_range: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Page Range",
+      description:
+        "Comma-separated list of page numbers or ranges to extract from (1-based, e.g., '1,3,5-7,9' or '1-3,8-10').",
     },
   },
   type: "object",
@@ -6563,6 +7005,20 @@ export const ExtractJobSchema = {
 
 export const ExtractJobCreateSchema = {
   properties: {
+    priority: {
+      anyOf: [
+        {
+          type: "string",
+          enum: ["low", "medium", "high", "critical"],
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Priority",
+      description:
+        "The priority for the request. This field may be ignored or overwritten depending on the organization tier.",
+    },
     webhook_configurations: {
       anyOf: [
         {
@@ -6739,16 +7195,16 @@ export const ExtractModeSchema = {
 export const ExtractModelsSchema = {
   type: "string",
   enum: [
-    "gpt-4.1",
-    "gpt-4.1-mini",
-    "gpt-4.1-nano",
+    "openai-gpt-4-1",
+    "openai-gpt-4-1-mini",
+    "openai-gpt-4-1-nano",
+    "openai-gpt-5",
+    "openai-gpt-5-mini",
     "gemini-2.0-flash",
-    "o3-mini",
     "gemini-2.5-flash",
     "gemini-2.5-pro",
-    "gemini-2.5-flash-lite-preview-06-17",
-    "gpt-4o",
-    "gpt-4o-mini",
+    "openai-gpt-4o",
+    "openai-gpt-4o-mini",
   ],
   title: "ExtractModels",
 } as const;
@@ -7284,6 +7740,109 @@ export const ExtractStateSchema = {
   title: "ExtractState",
 } as const;
 
+export const ExtractStatelessRequestSchema = {
+  properties: {
+    webhook_configurations: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/WebhookConfiguration",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Webhook Configurations",
+      description: "The outbound webhook configurations",
+    },
+    data_schema: {
+      anyOf: [
+        {
+          additionalProperties: {
+            anyOf: [
+              {
+                additionalProperties: true,
+                type: "object",
+              },
+              {
+                items: {},
+                type: "array",
+              },
+              {
+                type: "string",
+              },
+              {
+                type: "integer",
+              },
+              {
+                type: "number",
+              },
+              {
+                type: "boolean",
+              },
+              {
+                type: "null",
+              },
+            ],
+          },
+          type: "object",
+        },
+        {
+          type: "string",
+        },
+      ],
+      title: "Data Schema",
+      description: "The schema of the data to extract",
+    },
+    config: {
+      $ref: "#/components/schemas/ExtractConfig",
+      description: "The configuration parameters for the extraction",
+    },
+    file_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "File Id",
+      description: "The ID of the file to extract from",
+    },
+    text: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Text",
+      description: "The text content to extract from",
+    },
+    file: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/FileData",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description: "The file data with base64 content and MIME type",
+    },
+  },
+  type: "object",
+  required: ["data_schema", "config"],
+  title: "ExtractStatelessRequest",
+  description: "Schema for stateless extraction requests.",
+} as const;
+
 export const ExtractTargetSchema = {
   type: "string",
   enum: ["PER_DOC", "PER_PAGE"],
@@ -7296,6 +7855,22 @@ export const FailPageModeSchema = {
   title: "FailPageMode",
   description:
     "Enum for representing the different available page error handling modes",
+} as const;
+
+export const FailureHandlingConfigSchema = {
+  properties: {
+    skip_list_failures: {
+      type: "boolean",
+      title: "Skip List Failures",
+      description:
+        "Whether to skip failed batches/lists and continue processing",
+      default: false,
+    },
+  },
+  type: "object",
+  title: "FailureHandlingConfig",
+  description:
+    "Configuration for handling different types of failures during data source processing.",
 } as const;
 
 export const FileSchema = {
@@ -7339,7 +7914,14 @@ export const FileSchema = {
       title: "Name",
     },
     external_file_id: {
-      type: "string",
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "External File Id",
       description: "The ID of the file in the external system",
     },
@@ -7482,9 +8064,73 @@ export const FileSchema = {
     },
   },
   type: "object",
-  required: ["id", "name", "external_file_id", "project_id"],
+  required: ["id", "name", "project_id"],
   title: "File",
   description: "Schema for a file.",
+} as const;
+
+export const FileClassificationSchema = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+      description: "Unique identifier",
+    },
+    created_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Created At",
+      description: "Creation datetime",
+    },
+    updated_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Updated At",
+      description: "Update datetime",
+    },
+    classify_job_id: {
+      type: "string",
+      format: "uuid",
+      title: "Classify Job Id",
+      description: "The ID of the classify job",
+    },
+    file_id: {
+      type: "string",
+      format: "uuid",
+      title: "File Id",
+      description: "The ID of the classified file",
+    },
+    result: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/ClassificationResult",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description: "The classification result",
+    },
+  },
+  type: "object",
+  required: ["id", "classify_job_id", "file_id"],
+  title: "FileClassification",
+  description: "A file classification.",
 } as const;
 
 export const FileCountByStatusResponseSchema = {
@@ -7797,6 +8443,113 @@ export const FileCreateFromUrlSchema = {
   title: "FileCreateFromUrl",
 } as const;
 
+export const FileDataSchema = {
+  properties: {
+    data: {
+      type: "string",
+      title: "Data",
+      description: "The file content as base64-encoded string",
+    },
+    mime_type: {
+      type: "string",
+      title: "Mime Type",
+      description:
+        "The MIME type of the file (e.g., 'application/pdf', 'text/plain')",
+    },
+  },
+  type: "object",
+  required: ["data", "mime_type"],
+  title: "FileData",
+  description: "Schema for file data with base64 content and MIME type.",
+} as const;
+
+export const FileFilterSchema = {
+  properties: {
+    project_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Project Id",
+      description: "Filter by project ID",
+    },
+    file_ids: {
+      anyOf: [
+        {
+          items: {
+            type: "string",
+            format: "uuid",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "File Ids",
+      description: "Filter by specific file IDs",
+    },
+    file_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "File Name",
+      description: "Filter by file name",
+    },
+    data_source_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Data Source Id",
+      description: "Filter by data source ID",
+    },
+    external_file_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "External File Id",
+      description: "Filter by external file ID",
+    },
+    only_manually_uploaded: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Only Manually Uploaded",
+      description:
+        "Filter only manually uploaded files (data_source_id is null)",
+    },
+  },
+  type: "object",
+  title: "FileFilter",
+  description: "Filter parameters for file queries.",
+} as const;
+
 export const FileIdPresignedUrlSchema = {
   properties: {
     url: {
@@ -7893,6 +8646,109 @@ export const FileParsePublicSchema = {
   type: "object",
   required: ["created_at", "status", "input_path", "data_path"],
   title: "FileParsePublic",
+} as const;
+
+export const FileQueryRequestSchema = {
+  properties: {
+    page_size: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Page Size",
+      description:
+        "The maximum number of items to return. The service may return fewer than this value. If unspecified, a default page size will be used. The maximum value is typically 1000; values above this will be coerced to the maximum.",
+    },
+    page_token: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Page Token",
+      description:
+        "A page token, received from a previous list call. Provide this to retrieve the subsequent page.",
+    },
+    filter: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/FileFilter",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description:
+        "A filter object or expression that filters resources listed in the response.",
+    },
+    order_by: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Order By",
+      description:
+        "A comma-separated list of fields to order by, sorted in ascending order. Use 'field_name desc' to specify descending order.",
+    },
+  },
+  type: "object",
+  title: "FileQueryRequest",
+  description:
+    "Request schema for querying files with pagination and filtering.",
+} as const;
+
+export const FileQueryResponseSchema = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/File",
+      },
+      type: "array",
+      title: "Items",
+      description: "The list of items.",
+    },
+    next_page_token: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Page Token",
+      description:
+        "A token, which can be sent as page_token to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+    },
+    total_size: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Size",
+      description:
+        "The total number of items available. This is only populated when specifically requested. The value may be an estimate and can be used for display purposes only.",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "FileQueryResponse",
+  description: "Response schema for paginated file queries.",
 } as const;
 
 export const FilterConditionSchema = {
@@ -8397,81 +9253,6 @@ export const HuggingFaceInferenceAPIEmbeddingConfigSchema = {
   title: "HuggingFaceInferenceAPIEmbeddingConfig",
 } as const;
 
-export const ImageBlockSchema = {
-  properties: {
-    block_type: {
-      type: "string",
-      const: "image",
-      title: "Block Type",
-      default: "image",
-    },
-    image: {
-      anyOf: [
-        {
-          type: "string",
-          format: "binary",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Image",
-    },
-    path: {
-      anyOf: [
-        {
-          type: "string",
-          format: "file-path",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Path",
-    },
-    url: {
-      anyOf: [
-        {
-          type: "string",
-          minLength: 1,
-          format: "uri",
-        },
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Url",
-    },
-    image_mimetype: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Image Mimetype",
-    },
-    detail: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Detail",
-    },
-  },
-  type: "object",
-  title: "ImageBlock",
-} as const;
-
 export const IngestionErrorResponseSchema = {
   properties: {
     job_id: {
@@ -8559,7 +9340,6 @@ export const JobNamesSchema = {
     "load_files_job",
     "playground_job",
     "pipeline_managed_ingestion_job",
-    "data_source_managed_ingestion_job",
     "data_source_update_dispatcher_job",
     "pipeline_file_update_dispatcher_job",
     "pipeline_file_updater_job",
@@ -9166,6 +9946,12 @@ export const LegacyParseJobConfigSchema = {
       description: "Whether to preserve layout alignment across pages.",
       default: false,
     },
+    preserveVerySmallText: {
+      type: "boolean",
+      title: "Preserveverysmalltext",
+      description: "Whether to preserve very small text lines.",
+      default: false,
+    },
     invalidateCache: {
       type: "boolean",
       title: "Invalidatecache",
@@ -9251,6 +10037,20 @@ export const LegacyParseJobConfigSchema = {
       ],
       title: "Spreadsheetextractsubtables",
       description: "Whether to extract subTables from spreadsheet.",
+      default: false,
+    },
+    spreadSheetForceFormulaComputation: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Spreadsheetforceformulacomputation",
+      description:
+        "Whether to force re-computation of spreadsheet cells containing formulas.",
       default: false,
     },
     extractLayout: {
@@ -10077,7 +10877,8 @@ export const LlamaExtractSettingsSchema = {
     use_pixel_extraction: {
       type: "boolean",
       title: "Use Pixel Extraction",
-      description: "Whether to use extraction over pixels for multimodal mode.",
+      description:
+        "DEPRECATED: Whether to use extraction over pixels for multimodal mode.",
       default: false,
     },
     llama_parse_params: {
@@ -10088,23 +10889,30 @@ export const LlamaExtractSettingsSchema = {
         parsing_instruction: "",
         disable_ocr: false,
         annotate_links: true,
-        adaptive_long_table: false,
+        adaptive_long_table: true,
         compact_markdown_table: false,
         disable_reconstruction: false,
         disable_image_extraction: false,
         invalidate_cache: false,
-        outlined_table_extraction: false,
+        outlined_table_extraction: true,
         merge_tables_across_pages_in_markdown: false,
         output_pdf_of_document: false,
         do_not_cache: false,
         fast_mode: false,
         skip_diagonal_text: false,
         preserve_layout_alignment_across_pages: false,
+        preserve_very_small_text: false,
         gpt4o_mode: false,
         do_not_unroll_columns: false,
         extract_layout: false,
         high_res_ocr: false,
         html_make_all_elements_visible: false,
+        layout_aware: false,
+        specialized_chart_parsing_agentic: false,
+        specialized_chart_parsing_plus: false,
+        specialized_chart_parsing_efficient: false,
+        specialized_image_parsing: false,
+        precise_bounding_box: false,
         html_remove_navigation_elements: false,
         html_remove_fixed_elements: false,
         guess_xlsx_sheet_name: false,
@@ -10125,6 +10933,8 @@ export const LlamaExtractSettingsSchema = {
         structured_output: false,
         extract_charts: false,
         spreadsheet_extract_sub_tables: false,
+        spreadsheet_force_formula_computation: false,
+        inline_images_in_markdown: false,
         strict_mode_image_extraction: false,
         strict_mode_image_ocr: false,
         strict_mode_reconstruction: false,
@@ -10135,9 +10945,15 @@ export const LlamaExtractSettingsSchema = {
         ignore_document_elements_for_layout_detection: false,
         output_tables_as_HTML: false,
         internal_is_screenshot_job: false,
+        parse_mode: "parse_page_with_llm",
         page_error_tolerance: 0.05,
         replace_failed_page_mode: "raw_text",
       },
+    },
+    multimodal_parse_resolution: {
+      $ref: "#/components/schemas/MultimodalParseResolution",
+      description: "The resolution to use for multimodal parsing.",
+      default: "medium",
     },
   },
   type: "object",
@@ -10148,6 +10964,21 @@ are exposed to the user.`,
 
 export const LlamaParseParametersSchema = {
   properties: {
+    webhook_configurations: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/WebhookConfiguration",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Webhook Configurations",
+      description: "The outbound webhook configurations",
+    },
     priority: {
       anyOf: [
         {
@@ -10350,6 +11181,18 @@ export const LlamaParseParametersSchema = {
       title: "Preserve Layout Alignment Across Pages",
       default: false,
     },
+    preserve_very_small_text: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Preserve Very Small Text",
+      default: false,
+    },
     gpt4o_mode: {
       anyOf: [
         {
@@ -10419,6 +11262,78 @@ export const LlamaParseParametersSchema = {
         },
       ],
       title: "Html Make All Elements Visible",
+      default: false,
+    },
+    layout_aware: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Layout Aware",
+      default: false,
+    },
+    specialized_chart_parsing_agentic: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Specialized Chart Parsing Agentic",
+      default: false,
+    },
+    specialized_chart_parsing_plus: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Specialized Chart Parsing Plus",
+      default: false,
+    },
+    specialized_chart_parsing_efficient: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Specialized Chart Parsing Efficient",
+      default: false,
+    },
+    specialized_image_parsing: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Specialized Image Parsing",
+      default: false,
+    },
+    precise_bounding_box: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Precise Bounding Box",
       default: false,
     },
     html_remove_navigation_elements: {
@@ -10974,6 +11889,30 @@ export const LlamaParseParametersSchema = {
       title: "Spreadsheet Extract Sub Tables",
       default: false,
     },
+    spreadsheet_force_formula_computation: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Spreadsheet Force Formula Computation",
+      default: false,
+    },
+    inline_images_in_markdown: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Inline Images In Markdown",
+      default: false,
+    },
     job_timeout_in_seconds: {
       anyOf: [
         {
@@ -11458,6 +12397,63 @@ export const ManagedIngestionStatusResponseSchema = {
   title: "ManagedIngestionStatusResponse",
 } as const;
 
+export const ManagedOpenAIEmbeddingSchema = {
+  properties: {
+    model_name: {
+      type: "string",
+      const: "openai-text-embedding-3-small",
+      title: "Model Name",
+      description: "The name of the OpenAI embedding model.",
+      default: "openai-text-embedding-3-small",
+    },
+    embed_batch_size: {
+      type: "integer",
+      maximum: 2048,
+      exclusiveMinimum: 0,
+      title: "Embed Batch Size",
+      description: "The batch size for embedding calls.",
+      default: 10,
+    },
+    num_workers: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Num Workers",
+      description: "The number of workers to use for async embedding calls.",
+    },
+    class_name: {
+      type: "string",
+      title: "Class Name",
+      default: "ManagedOpenAIEmbedding",
+    },
+  },
+  type: "object",
+  title: "ManagedOpenAIEmbedding",
+} as const;
+
+export const ManagedOpenAIEmbeddingConfigSchema = {
+  properties: {
+    type: {
+      type: "string",
+      const: "MANAGED_OPENAI_EMBEDDING",
+      title: "Type",
+      description: "Type of the embedding model.",
+      default: "MANAGED_OPENAI_EMBEDDING",
+    },
+    component: {
+      $ref: "#/components/schemas/ManagedOpenAIEmbedding",
+      description: "Configuration for the Managed OpenAI embedding model.",
+    },
+  },
+  type: "object",
+  title: "ManagedOpenAIEmbeddingConfig",
+} as const;
+
 export const MessageAnnotationSchema = {
   properties: {
     type: {
@@ -11604,6 +12600,12 @@ export const MetronomeDashboardTypeSchema = {
   type: "string",
   enum: ["invoices", "usage"],
   title: "MetronomeDashboardType",
+} as const;
+
+export const MultimodalParseResolutionSchema = {
+  type: "string",
+  enum: ["medium", "high"],
+  title: "MultimodalParseResolution",
 } as const;
 
 export const NodeRelationshipSchema = {
@@ -11859,6 +12861,19 @@ export const OrganizationSchema = {
       description: "Whether the organization is a Parse Premium customer.",
       default: "DEFAULT",
     },
+    feature_flags: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Feature Flags",
+      description: "Feature flags for the organization.",
+    },
   },
   type: "object",
   required: ["id", "name"],
@@ -11890,6 +12905,19 @@ export const OrganizationUpdateSchema = {
       minLength: 1,
       title: "Name",
       description: "A name for the organization.",
+    },
+    feature_flags: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Feature Flags",
+      description: "Feature flags for the organization.",
     },
   },
   type: "object",
@@ -12245,33 +13273,6 @@ export const PaginatedListPipelineFilesResponseSchema = {
   title: "PaginatedListPipelineFilesResponse",
 } as const;
 
-export const PaginatedReportResponseSchema = {
-  properties: {
-    report_responses: {
-      items: {
-        $ref: "#/components/schemas/ReportResponse",
-      },
-      type: "array",
-      title: "Report Responses",
-    },
-    limit: {
-      type: "integer",
-      title: "Limit",
-    },
-    offset: {
-      type: "integer",
-      title: "Offset",
-    },
-    total_count: {
-      type: "integer",
-      title: "Total Count",
-    },
-  },
-  type: "object",
-  required: ["report_responses", "limit", "offset", "total_count"],
-  title: "PaginatedReportResponse",
-} as const;
-
 export const PaginatedResponse_AgentData_Schema = {
   properties: {
     items: {
@@ -12356,8 +13357,431 @@ export const PaginatedResponse_AggregateGroup_Schema = {
   title: "PaginatedResponse[AggregateGroup]",
 } as const;
 
+export const PaginatedResponse_ClassifyJob_Schema = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/ClassifyJob",
+      },
+      type: "array",
+      title: "Items",
+      description: "The list of items.",
+    },
+    next_page_token: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Page Token",
+      description:
+        "A token, which can be sent as page_token to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+    },
+    total_size: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Size",
+      description:
+        "The total number of items available. This is only populated when specifically requested. The value may be an estimate and can be used for display purposes only.",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "PaginatedResponse[ClassifyJob]",
+} as const;
+
+export const PaginatedResponse_QuotaConfiguration_Schema = {
+  properties: {
+    total: {
+      type: "integer",
+      title: "Total",
+    },
+    page: {
+      type: "integer",
+      title: "Page",
+    },
+    size: {
+      type: "integer",
+      title: "Size",
+    },
+    pages: {
+      type: "integer",
+      title: "Pages",
+    },
+    items: {
+      items: {
+        $ref: "#/components/schemas/QuotaConfiguration",
+      },
+      type: "array",
+      title: "Items",
+    },
+  },
+  type: "object",
+  required: ["total", "page", "size", "pages", "items"],
+  title: "PaginatedResponse[QuotaConfiguration]",
+} as const;
+
+export const ParseConfigurationSchema = {
+  properties: {
+    id: {
+      type: "string",
+      title: "Id",
+      description: "Unique identifier for the parse configuration",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+      description: "Name of the parse configuration",
+    },
+    source_type: {
+      type: "string",
+      title: "Source Type",
+      description: "Type of the source (e.g., 'project')",
+    },
+    source_id: {
+      type: "string",
+      title: "Source Id",
+      description: "ID of the source",
+    },
+    creator: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Creator",
+      description: "Creator of the configuration",
+    },
+    version: {
+      type: "string",
+      title: "Version",
+      description: "Version of the configuration",
+    },
+    parameters: {
+      $ref: "#/components/schemas/LlamaParseParameters",
+      description: "LlamaParseParameters configuration",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+      description: "Creation timestamp",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+      description: "Last update timestamp",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "name",
+    "source_type",
+    "source_id",
+    "version",
+    "parameters",
+    "created_at",
+    "updated_at",
+  ],
+  title: "ParseConfiguration",
+  description: "Parse configuration schema.",
+} as const;
+
+export const ParseConfigurationCreateSchema = {
+  properties: {
+    name: {
+      type: "string",
+      title: "Name",
+      description: "Name of the parse configuration",
+    },
+    source_type: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Source Type",
+      description: "Type of the source (e.g., 'project')",
+    },
+    source_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Source Id",
+      description: "ID of the source",
+    },
+    creator: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Creator",
+      description: "Creator of the configuration",
+    },
+    version: {
+      type: "string",
+      title: "Version",
+      description: "Version of the configuration",
+    },
+    parameters: {
+      $ref: "#/components/schemas/LlamaParseParameters",
+      description: "LlamaParseParameters configuration",
+    },
+  },
+  type: "object",
+  required: ["name", "version", "parameters"],
+  title: "ParseConfigurationCreate",
+  description: "Schema for creating a new parse configuration (API boundary).",
+} as const;
+
+export const ParseConfigurationFilterSchema = {
+  properties: {
+    name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Name",
+      description: "Filter by name",
+    },
+    source_type: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Source Type",
+      description: "Filter by source type",
+    },
+    source_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Source Id",
+      description: "Filter by source ID",
+    },
+    creator: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Creator",
+      description: "Filter by creator",
+    },
+    version: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Version",
+      description: "Filter by version",
+    },
+    parse_config_ids: {
+      anyOf: [
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Parse Config Ids",
+      description: "Filter by specific parse configuration IDs",
+    },
+  },
+  type: "object",
+  title: "ParseConfigurationFilter",
+  description: "Filter parameters for parse configuration queries.",
+} as const;
+
+export const ParseConfigurationQueryRequestSchema = {
+  properties: {
+    page_size: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Page Size",
+      description:
+        "The maximum number of items to return. The service may return fewer than this value. If unspecified, a default page size will be used. The maximum value is typically 1000; values above this will be coerced to the maximum.",
+    },
+    page_token: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Page Token",
+      description:
+        "A page token, received from a previous list call. Provide this to retrieve the subsequent page.",
+    },
+    filter: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/ParseConfigurationFilter",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description:
+        "A filter object or expression that filters resources listed in the response.",
+    },
+    order_by: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Order By",
+      description:
+        "A comma-separated list of fields to order by, sorted in ascending order. Use 'field_name desc' to specify descending order.",
+    },
+  },
+  type: "object",
+  title: "ParseConfigurationQueryRequest",
+  description:
+    "Request schema for querying parse configurations with pagination and filtering.",
+} as const;
+
+export const ParseConfigurationQueryResponseSchema = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/ParseConfiguration",
+      },
+      type: "array",
+      title: "Items",
+      description: "The list of items.",
+    },
+    next_page_token: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Page Token",
+      description:
+        "A token, which can be sent as page_token to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+    },
+    total_size: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Size",
+      description:
+        "The total number of items available. This is only populated when specifically requested. The value may be an estimate and can be used for display purposes only.",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "ParseConfigurationQueryResponse",
+  description: "Response schema for paginated parse configuration queries.",
+} as const;
+
+export const ParseConfigurationUpdateSchema = {
+  properties: {
+    parameters: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/LlamaParseParameters",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description: "Updated LlamaParseParameters configuration",
+    },
+  },
+  type: "object",
+  title: "ParseConfigurationUpdate",
+  description: "Schema for updating an existing parse configuration.",
+} as const;
+
 export const ParseJobConfigSchema = {
   properties: {
+    webhook_configurations: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/WebhookConfiguration",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Webhook Configurations",
+      description: "The outbound webhook configurations",
+    },
     priority: {
       anyOf: [
         {
@@ -12586,6 +14010,18 @@ export const ParseJobConfigSchema = {
       title: "Preserve Layout Alignment Across Pages",
       default: false,
     },
+    preserve_very_small_text: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Preserve Very Small Text",
+      default: false,
+    },
     gpt4o_mode: {
       anyOf: [
         {
@@ -12655,6 +14091,78 @@ export const ParseJobConfigSchema = {
         },
       ],
       title: "Html Make All Elements Visible",
+      default: false,
+    },
+    layout_aware: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Layout Aware",
+      default: false,
+    },
+    specialized_chart_parsing_agentic: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Specialized Chart Parsing Agentic",
+      default: false,
+    },
+    specialized_chart_parsing_plus: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Specialized Chart Parsing Plus",
+      default: false,
+    },
+    specialized_chart_parsing_efficient: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Specialized Chart Parsing Efficient",
+      default: false,
+    },
+    specialized_image_parsing: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Specialized Image Parsing",
+      default: false,
+    },
+    precise_bounding_box: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Precise Bounding Box",
       default: false,
     },
     html_remove_navigation_elements: {
@@ -13214,6 +14722,30 @@ export const ParseJobConfigSchema = {
         },
       ],
       title: "Spreadsheet Extract Sub Tables",
+      default: false,
+    },
+    spreadsheet_force_formula_computation: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Spreadsheet Force Formula Computation",
+      default: false,
+    },
+    inline_images_in_markdown: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Inline Images In Markdown",
       default: false,
     },
     job_timeout_in_seconds: {
@@ -13993,6 +15525,17 @@ export const PipelineSchema = {
       title: "Embedding Model Config Id",
       description: "The ID of the EmbeddingModelConfig this pipeline is using.",
     },
+    embedding_model_config: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/EmbeddingModelConfig",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description: "The embedding model configuration for this pipeline.",
+    },
     pipeline_type: {
       $ref: "#/components/schemas/PipelineType",
       description: "Type of pipeline. Either PLAYGROUND or MANAGED.",
@@ -14014,6 +15557,9 @@ export const PipelineSchema = {
     },
     embedding_config: {
       oneOf: [
+        {
+          $ref: "#/components/schemas/ManagedOpenAIEmbeddingConfig",
+        },
         {
           $ref: "#/components/schemas/AzureOpenAIEmbeddingConfig",
         },
@@ -14046,10 +15592,23 @@ export const PipelineSchema = {
           GEMINI_EMBEDDING: "#/components/schemas/GeminiEmbeddingConfig",
           HUGGINGFACE_API_EMBEDDING:
             "#/components/schemas/HuggingFaceInferenceAPIEmbeddingConfig",
+          MANAGED_OPENAI_EMBEDDING:
+            "#/components/schemas/ManagedOpenAIEmbeddingConfig",
           OPENAI_EMBEDDING: "#/components/schemas/OpenAIEmbeddingConfig",
           VERTEXAI_EMBEDDING: "#/components/schemas/VertexAIEmbeddingConfig",
         },
       },
+    },
+    sparse_model_config: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/SparseModelConfig",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description: "Configuration for the sparse model used in hybrid search.",
     },
     config_hash: {
       anyOf: [
@@ -14248,6 +15807,17 @@ export const PipelineCreateSchema = {
       ],
       title: "Transform Config",
       description: "Configuration for the transformation.",
+    },
+    sparse_model_config: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/SparseModelConfig",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description: "Configuration for the sparse model used in hybrid search.",
     },
     data_sink_id: {
       anyOf: [
@@ -14466,6 +16036,9 @@ export const PipelineDataSourceSchema = {
         },
         {
           $ref: "#/components/schemas/CloudJiraDataSource",
+        },
+        {
+          $ref: "#/components/schemas/CloudJiraDataSourceV2",
         },
         {
           $ref: "#/components/schemas/CloudBoxDataSource",
@@ -14740,6 +16313,7 @@ export const PipelineFileSchema = {
         },
       ],
       title: "Name",
+      description: "Name of the file",
     },
     external_file_id: {
       anyOf: [
@@ -14781,8 +16355,15 @@ export const PipelineFileSchema = {
       description: "File type (e.g. pdf, docx, etc.)",
     },
     project_id: {
-      type: "string",
-      format: "uuid",
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Project Id",
       description: "The ID of the project that the file belongs to",
     },
@@ -14798,6 +16379,25 @@ export const PipelineFileSchema = {
       ],
       title: "Last Modified At",
       description: "The last modified time of the file",
+    },
+    file_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "File Id",
+      description: "The ID of the file",
+    },
+    pipeline_id: {
+      type: "string",
+      format: "uuid",
+      title: "Pipeline Id",
+      description: "The ID of the pipeline that the file is associated with",
     },
     resource_info: {
       anyOf: [
@@ -14877,38 +16477,6 @@ export const PipelineFileSchema = {
       title: "Permission Info",
       description: "Permission information for the file",
     },
-    data_source_id: {
-      anyOf: [
-        {
-          type: "string",
-          format: "uuid",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Data Source Id",
-      description: "The ID of the data source that the file belongs to",
-    },
-    file_id: {
-      anyOf: [
-        {
-          type: "string",
-          format: "uuid",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "File Id",
-      description: "The ID of the file",
-    },
-    pipeline_id: {
-      type: "string",
-      format: "uuid",
-      title: "Pipeline Id",
-      description: "The ID of the pipeline that the file is associated with",
-    },
     custom_metadata: {
       anyOf: [
         {
@@ -14947,6 +16515,19 @@ export const PipelineFileSchema = {
       ],
       title: "Custom Metadata",
       description: "Custom metadata for the file",
+    },
+    data_source_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Data Source Id",
+      description: "The ID of the data source that the file belongs to",
     },
     config_hash: {
       anyOf: [
@@ -15027,7 +16608,7 @@ export const PipelineFileSchema = {
     },
   },
   type: "object",
-  required: ["id", "project_id", "pipeline_id"],
+  required: ["id", "pipeline_id"],
   title: "PipelineFile",
   description: "Schema for a file that is associated with a pipeline.",
 } as const;
@@ -15409,6 +16990,17 @@ export const PipelineUpdateSchema = {
       title: "Transform Config",
       description: "Configuration for the transformation.",
     },
+    sparse_model_config: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/SparseModelConfig",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description: "Configuration for the sparse model used in hybrid search.",
+    },
     data_sink_id: {
       anyOf: [
         {
@@ -15482,6 +17074,7 @@ export const PipelineUpdateSchema = {
       ],
       description:
         "Settings that can be configured for how to use LlamaParse to parse files within a LlamaCloud pipeline.",
+      deprecated: true,
     },
     status: {
       anyOf: [
@@ -15862,7 +17455,7 @@ export const PlaygroundSessionSchema = {
     },
     chat_messages: {
       items: {
-        $ref: "#/components/schemas/src__app__schema__chat__ChatMessage",
+        $ref: "#/components/schemas/ChatMessage",
       },
       type: "array",
       title: "Chat Messages",
@@ -16147,80 +17740,6 @@ export const PresignedUrlSchema = {
   description: "Schema for a presigned URL.",
 } as const;
 
-export const ProgressEventSchema = {
-  properties: {
-    timestamp: {
-      type: "string",
-      format: "date-time",
-      title: "Timestamp",
-    },
-    id: {
-      type: "string",
-      format: "uuid",
-      title: "Id",
-      description: "The ID of the event",
-    },
-    group_id: {
-      type: "string",
-      format: "uuid",
-      title: "Group Id",
-      description: "The ID of the group this event belongs to",
-    },
-    type: {
-      type: "string",
-      const: "progress",
-      title: "Type",
-      default: "progress",
-    },
-    variant: {
-      $ref: "#/components/schemas/ReportEventType",
-    },
-    msg: {
-      type: "string",
-      title: "Msg",
-      description: "The message to display to the user",
-    },
-    progress: {
-      anyOf: [
-        {
-          type: "number",
-          maximum: 1,
-          minimum: 0,
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Progress",
-      description: "Progress value between 0-1 if available",
-    },
-    status: {
-      type: "string",
-      enum: ["pending", "in_progress", "completed", "error"],
-      title: "Status",
-      description: "Current status of the operation",
-      default: "pending",
-    },
-    extra_detail: {
-      anyOf: [
-        {
-          additionalProperties: true,
-          type: "object",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Extra Detail",
-      description: "Any extra details to display to the user",
-    },
-  },
-  type: "object",
-  required: ["variant", "msg"],
-  title: "ProgressEvent",
-  description: "Event for tracking progress of operations in workflows.",
-} as const;
-
 export const ProjectSchema = {
   properties: {
     name: {
@@ -16351,7 +17870,7 @@ export const PromptConfSchema = {
       default: `
 Provide a brief explanation for how you arrived at the extracted value based on the source text provided.
 - For inferred values, explain the reasoning behind the extraction briefly.
-- For simple verbatim extraction, output 'VERBATIM EXTRACTION'. 
+- For simple verbatim extraction, output 'VERBATIM EXTRACTION'.
 - When supporting data is not present in the source text, output 'INSUFFICIENT DATA' and emit blank or null values for the value__ field.
 `,
     },
@@ -16365,13 +17884,13 @@ Provide a brief explanation for how you arrived at the extracted value based on 
       default: {
         description: `
 ### Citation Rules (read carefully):
-- You must ANNOTATE every value with a short EXACT substring from the source text that supports it.
-- For inferred values, cite the text used to infer it or output 'INFERRED FROM TEXT'
+- You must ANNOTATE every value with the MOST RELEVANT short EXACT substring from the source text that supports it.
+- For inferred values, cite the text used to infer it in the matching_text field or output 'INFERRED FROM TEXT'
 - If no support exists, output 'INSUFFICIENT DATA' and leave value__ null or '', 0.0, False etc depending on the type of the field.
 `,
         page: "Cite the page number of the source text that the extracted value is from. The page number is the integer that appears right after <<<PAGE:. If no page number is present in this format, use the default value of 1.",
         matching_text:
-          'Cite the **EXACT TEXT from the SOURCE TEXT** that supports the extracted value within 120 characters. If the exact substring is >120 chars, truncate with ellipsis "...".',
+          'Cite the **MOST RELEVANT EXACT TEXT from the SOURCE TEXT** that supports the extracted value within 80 characters. If the exact substring is >80 chars, truncate with ellipsis "...". Provide only the single most relevant citation.',
       },
     },
     scratchpad_prompt: {
@@ -16383,6 +17902,207 @@ Provide a brief explanation for how you arrived at the extracted value based on 
   },
   type: "object",
   title: "PromptConf",
+} as const;
+
+export const PublicModelNameSchema = {
+  type: "string",
+  enum: [
+    "openai-gpt-4o",
+    "openai-gpt-4o-mini",
+    "openai-gpt-4-1",
+    "openai-gpt-4-1-mini",
+    "openai-gpt-4-1-nano",
+    "openai-gpt-5",
+    "openai-gpt-5-mini",
+    "openai-gpt-5-nano",
+    "openai-text-embedding-3-small",
+    "openai-text-embedding-3-large",
+    "openai-whisper-1",
+    "anthropic-sonnet-3.5",
+    "anthropic-sonnet-3.5-v2",
+    "anthropic-sonnet-3.7",
+    "anthropic-sonnet-4.0",
+    "gemini-2.5-flash",
+    "gemini-2.5-pro",
+    "gemini-2.0-flash",
+    "gemini-2.0-flash-lite",
+    "gemini-1.5-flash",
+    "gemini-1.5-pro",
+  ],
+  title: "PublicModelName",
+} as const;
+
+export const QuotaConfigurationSchema = {
+  properties: {
+    source_type: {
+      type: "string",
+      const: "organization",
+      title: "Source Type",
+      description: "The source type, e.g. 'organization'",
+    },
+    source_id: {
+      type: "string",
+      title: "Source Id",
+      description: "The source ID, e.g. the organization ID",
+    },
+    configuration_type: {
+      type: "string",
+      enum: [
+        "rate_limit_parse_concurrent_premium",
+        "rate_limit_parse_concurrent_default",
+        "rate_limit_concurrent_jobs_in_execution_default",
+        "rate_limit_concurrent_jobs_in_execution_doc_ingest",
+        "limit_embedding_character",
+      ],
+      title: "Configuration Type",
+      description: "The quota configuration type",
+    },
+    configuration_value: {
+      $ref: "#/components/schemas/QuotaRateLimitConfigurationValue",
+      description: "The quota configuration value",
+    },
+    configuration_metadata: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Configuration Metadata",
+      description: "The configuration metadata",
+    },
+    started_at: {
+      type: "string",
+      format: "date-time",
+      title: "Started At",
+      description: "The start date of the quota",
+    },
+    ended_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Ended At",
+      description: "The end date of the quota",
+    },
+    idempotency_key: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Idempotency Key",
+      description: "The idempotency key",
+    },
+    status: {
+      type: "string",
+      enum: ["ACTIVE", "INACTIVE"],
+      title: "Status",
+      description: "The status of the quota, i.e. 'ACTIVE' or 'INACTIVE'",
+    },
+    id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Id",
+      description: "The system-generated UUID for the quota",
+    },
+    created_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Created At",
+      description:
+        "The creation date of the quota configuration in the database",
+    },
+    updated_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Updated At",
+      description:
+        "The last updated date of the quota configuration in the database",
+    },
+  },
+  type: "object",
+  required: [
+    "source_type",
+    "source_id",
+    "configuration_type",
+    "configuration_value",
+    "configuration_metadata",
+    "status",
+  ],
+  title: "QuotaConfiguration",
+  description: "Full quota configuration model.",
+} as const;
+
+export const QuotaRateLimitConfigurationValueSchema = {
+  properties: {
+    numerator: {
+      type: "integer",
+      title: "Numerator",
+      description: "The rate numerator",
+    },
+    denominator: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Denominator",
+      description: "The rate limit denominator",
+    },
+    denominator_units: {
+      anyOf: [
+        {
+          type: "string",
+          enum: ["second", "minute", "hour", "day"],
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Denominator Units",
+      description: "The default rate limit denominator units",
+    },
+  },
+  type: "object",
+  required: ["numerator"],
+  title: "QuotaRateLimitConfigurationValue",
+  description: "Quota-specific wrapper for default rate limit configuration.",
 } as const;
 
 export const ReRankConfigSchema = {
@@ -16507,446 +18227,25 @@ export const RelatedNodeInfoSchema = {
   title: "RelatedNodeInfo",
 } as const;
 
-export const ReportSchema = {
+export const RestrictSchema = {
   properties: {
-    id: {
-      type: "string",
-      format: "uuid",
-      title: "Id",
-      description: "The id of the report",
-    },
-    blocks: {
-      items: {
-        $ref: "#/components/schemas/ReportBlock",
-      },
-      type: "array",
-      title: "Blocks",
-      description: "The blocks of the report",
-    },
-  },
-  type: "object",
-  required: ["id"],
-  title: "Report",
-} as const;
-
-export const ReportBlockSchema = {
-  properties: {
-    idx: {
-      type: "integer",
-      title: "Idx",
-      description: "The index of the block",
-    },
-    template: {
-      type: "string",
-      title: "Template",
-      description: "The content of the block",
-    },
-    requires_human_review: {
-      type: "boolean",
-      title: "Requires Human Review",
-      description: "Whether the block requires human review",
-      default: false,
-    },
-    sources: {
-      items: {
-        $ref: "#/components/schemas/TextNodeWithScore",
-      },
-      type: "array",
-      title: "Sources",
-      description: "The sources for the block",
-    },
-  },
-  type: "object",
-  required: ["idx", "template"],
-  title: "ReportBlock",
-} as const;
-
-export const ReportBlockDependencySchema = {
-  type: "string",
-  enum: ["none", "all", "previous", "next"],
-  title: "ReportBlockDependency",
-} as const;
-
-export const ReportCreateResponseSchema = {
-  properties: {
-    id: {
-      type: "string",
-      format: "uuid",
-      title: "Id",
-      description: "The id of the report",
-    },
-  },
-  type: "object",
-  required: ["id"],
-  title: "ReportCreateResponse",
-} as const;
-
-export const ReportEventItemSchema = {
-  properties: {
-    id: {
-      type: "string",
-      format: "uuid",
-      title: "Id",
-      description: "The id of the event",
-    },
-    report_id: {
-      type: "string",
-      format: "uuid",
-      title: "Report Id",
-      description: "The id of the report",
-    },
-    event_type: {
-      type: "string",
-      title: "Event Type",
-      description: "The type of the event",
-    },
-    event_data: {
-      anyOf: [
-        {
-          $ref: "#/components/schemas/ProgressEvent",
-        },
-        {
-          $ref: "#/components/schemas/ReportUpdateEvent",
-        },
-        {
-          $ref: "#/components/schemas/ReportStateEvent",
-        },
-      ],
-      title: "Event Data",
-      description: "The data for the event",
-    },
-    timestamp: {
-      type: "string",
-      format: "date-time",
-      title: "Timestamp",
-      description: "The timestamp for the event",
-    },
-  },
-  type: "object",
-  required: ["id", "report_id", "event_type", "event_data", "timestamp"],
-  title: "ReportEventItem",
-  description: "From backend schema",
-} as const;
-
-export const ReportEventTypeSchema = {
-  type: "string",
-  enum: [
-    "load_template",
-    "extract_plan",
-    "summarize",
-    "file_processing",
-    "generate_block",
-    "editing",
-  ],
-  title: "ReportEventType",
-} as const;
-
-export const ReportMetadataSchema = {
-  properties: {
-    id: {
-      type: "string",
-      format: "uuid",
-      title: "Id",
-      description: "The id of the report",
-    },
-    name: {
-      type: "string",
-      title: "Name",
-      description: "The name of the report",
-    },
-    report_metadata: {
-      additionalProperties: true,
-      type: "object",
-      title: "Report Metadata",
-      description: "The metadata for the report",
-    },
-    state: {
-      $ref: "#/components/schemas/ReportState",
-      description: "The state of the report",
-    },
-    input_files: {
-      anyOf: [
-        {
-          items: {
-            type: "string",
-          },
-          type: "array",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Input Files",
-    },
-    template_file: {
+    project_id: {
       anyOf: [
         {
           type: "string",
+          format: "uuid",
         },
         {
           type: "null",
         },
       ],
-      title: "Template File",
-    },
-    template_text: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Template Text",
-    },
-    template_instructions: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Template Instructions",
+      title: "Project Id",
+      description: "The project ID to restrict the user to.",
     },
   },
   type: "object",
-  required: ["id", "name", "report_metadata", "state"],
-  title: "ReportMetadata",
-  description: "Used to update the metadata of a report.",
-} as const;
-
-export const ReportNameUpdateSchema = {
-  properties: {
-    name: {
-      type: "string",
-      title: "Name",
-      description: "The name of the report",
-    },
-  },
-  type: "object",
-  required: ["name"],
-  title: "ReportNameUpdate",
-} as const;
-
-export const ReportPlanSchema = {
-  properties: {
-    id: {
-      type: "string",
-      format: "uuid",
-      title: "Id",
-      description: "The id of the report plan",
-    },
-    blocks: {
-      items: {
-        $ref: "#/components/schemas/ReportPlanBlock",
-      },
-      type: "array",
-      title: "Blocks",
-      description: "The blocks of the report",
-    },
-    generated_at: {
-      type: "string",
-      format: "date-time",
-      title: "Generated At",
-      description: "The timestamp of when the plan was generated",
-    },
-  },
-  type: "object",
-  title: "ReportPlan",
-} as const;
-
-export const ReportPlanBlockSchema = {
-  properties: {
-    block: {
-      $ref: "#/components/schemas/ReportBlock",
-    },
-    queries: {
-      items: {
-        $ref: "#/components/schemas/ReportQuery",
-      },
-      type: "array",
-      title: "Queries",
-      description: "The queries for the block",
-    },
-    dependency: {
-      $ref: "#/components/schemas/ReportBlockDependency",
-      description: "The dependency for the block",
-    },
-  },
-  type: "object",
-  required: ["block", "dependency"],
-  title: "ReportPlanBlock",
-} as const;
-
-export const ReportQuerySchema = {
-  properties: {
-    field: {
-      type: "string",
-      title: "Field",
-      description: "The field in the template that needs to be filled in",
-    },
-    prompt: {
-      type: "string",
-      title: "Prompt",
-      description: "The prompt for filling in the field",
-    },
-    context: {
-      type: "string",
-      title: "Context",
-      description: "Any additional context for the query",
-    },
-  },
-  type: "object",
-  required: ["field", "prompt", "context"],
-  title: "ReportQuery",
-} as const;
-
-export const ReportResponseSchema = {
-  properties: {
-    name: {
-      type: "string",
-      title: "Name",
-    },
-    report_id: {
-      type: "string",
-      format: "uuid",
-      title: "Report Id",
-    },
-    report: {
-      anyOf: [
-        {
-          $ref: "#/components/schemas/Report",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    plan: {
-      anyOf: [
-        {
-          $ref: "#/components/schemas/ReportPlan",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    version: {
-      type: "integer",
-      title: "Version",
-    },
-    last_updated: {
-      type: "string",
-      format: "date-time",
-      title: "Last Updated",
-    },
-    status: {
-      $ref: "#/components/schemas/ReportState",
-    },
-    total_versions: {
-      type: "integer",
-      title: "Total Versions",
-    },
-  },
-  type: "object",
-  required: [
-    "name",
-    "report_id",
-    "report",
-    "plan",
-    "version",
-    "last_updated",
-    "status",
-    "total_versions",
-  ],
-  title: "ReportResponse",
-} as const;
-
-export const ReportStateSchema = {
-  type: "string",
-  enum: [
-    "pending",
-    "planning",
-    "waiting_approval",
-    "generating",
-    "completed",
-    "error",
-  ],
-  title: "ReportState",
-} as const;
-
-export const ReportStateEventSchema = {
-  properties: {
-    timestamp: {
-      type: "string",
-      format: "date-time",
-      title: "Timestamp",
-    },
-    type: {
-      type: "string",
-      const: "report_state_update",
-      title: "Type",
-    },
-    msg: {
-      type: "string",
-      title: "Msg",
-      description: "The message to display to the user",
-    },
-    status: {
-      $ref: "#/components/schemas/ReportState",
-      description: "The new state of the report",
-    },
-  },
-  type: "object",
-  required: ["type", "msg", "status"],
-  title: "ReportStateEvent",
-  description: "Event for notifying when an report's state changes.",
-} as const;
-
-export const ReportUpdateEventSchema = {
-  properties: {
-    timestamp: {
-      type: "string",
-      format: "date-time",
-      title: "Timestamp",
-    },
-    type: {
-      type: "string",
-      const: "report_block_update",
-      title: "Type",
-      default: "report_block_update",
-    },
-    msg: {
-      type: "string",
-      title: "Msg",
-      description: "The message to display to the user",
-      default: "A block has been generated and is ready to be displayed",
-    },
-    block: {
-      $ref: "#/components/schemas/ReportBlock",
-      description: "The block to update",
-    },
-  },
-  type: "object",
-  required: ["block"],
-  title: "ReportUpdateEvent",
-  description: "Event for updating the state of an report.",
-} as const;
-
-export const ReportVersionPatchSchema = {
-  properties: {
-    content: {
-      $ref: "#/components/schemas/Report",
-      description: "The content of the report version",
-    },
-  },
-  type: "object",
-  required: ["content"],
-  title: "ReportVersionPatch",
+  required: ["project_id"],
+  title: "Restrict",
 } as const;
 
 export const RetrievalModeSchema = {
@@ -17519,7 +18818,7 @@ export const SearchRequestSchema = {
     deployment_name: {
       type: "string",
       title: "Deployment Name",
-      description: "The agent deployment's deployment_name to search within",
+      description: "The agent deployment's name to search within",
     },
     collection: {
       type: "string",
@@ -17538,6 +18837,7 @@ export const SearchRequestSchema = {
       anyOf: [
         {
           type: "integer",
+          maximum: 1000,
           minimum: 0,
         },
         {
@@ -17548,7 +18848,6 @@ export const SearchRequestSchema = {
       description:
         "The offset to start from. If not provided, the first page is returned",
       default: 0,
-      lte: 1000,
     },
   },
   type: "object",
@@ -17618,6 +18917,39 @@ export const SentenceChunkingConfigSchema = {
   title: "SentenceChunkingConfig",
 } as const;
 
+export const SparseModelConfigSchema = {
+  properties: {
+    model_type: {
+      $ref: "#/components/schemas/SparseModelType",
+      description:
+        "The sparse model type to use. 'auto' selects based on deployment mode (BYOC uses term frequency, Cloud uses Splade), 'splade' uses HuggingFace Splade model, 'bm25' uses Qdrant's FastEmbed BM25 model.",
+      default: "auto",
+    },
+    class_name: {
+      type: "string",
+      title: "Class Name",
+      default: "SparseModelConfig",
+    },
+  },
+  type: "object",
+  title: "SparseModelConfig",
+  description: `Configuration for sparse embedding models used in hybrid search.
+
+This allows users to choose between Splade and BM25 models for
+sparse retrieval in managed data sinks.`,
+} as const;
+
+export const SparseModelTypeSchema = {
+  type: "string",
+  enum: ["splade", "bm25", "auto"],
+  title: "SparseModelType",
+  description: `Enum for sparse model types supported in LlamaCloud.
+
+SPLADE: Uses HuggingFace Splade model for sparse embeddings
+BM25: Uses Qdrant's FastEmbed BM25 model for sparse embeddings
+AUTO: Automatically selects based on deployment mode (BYOC uses term frequency, Cloud uses Splade)`,
+} as const;
+
 export const StatusEnumSchema = {
   type: "string",
   enum: ["PENDING", "SUCCESS", "ERROR", "PARTIAL_SUCCESS", "CANCELLED"],
@@ -17642,7 +18974,7 @@ export const StructParseConfSchema = {
     model: {
       $ref: "#/components/schemas/ExtractModels",
       description: "The model to use for the structured parsing.",
-      default: "gpt-4.1",
+      default: "openai-gpt-4-1",
     },
     temperature: {
       type: "number",
@@ -17659,6 +18991,12 @@ export const StructParseConfSchema = {
       $ref: "#/components/schemas/StructMode",
       description: "The struct mode to use for the structured parsing.",
       default: "STRUCT_PARSE",
+    },
+    fetch_logprobs: {
+      type: "boolean",
+      title: "Fetch Logprobs",
+      description: "Whether to fetch logprobs for the structured parsing.",
+      default: false,
     },
     handle_missing: {
       type: "boolean",
@@ -17690,18 +19028,18 @@ export const StructParseConfSchema = {
         reasoning_prompt: `
 Provide a brief explanation for how you arrived at the extracted value based on the source text provided.
 - For inferred values, explain the reasoning behind the extraction briefly.
-- For simple verbatim extraction, output 'VERBATIM EXTRACTION'. 
+- For simple verbatim extraction, output 'VERBATIM EXTRACTION'.
 - When supporting data is not present in the source text, output 'INSUFFICIENT DATA' and emit blank or null values for the value__ field.
 `,
         cite_sources_prompt: {
           description: `
 ### Citation Rules (read carefully):
-- You must ANNOTATE every value with a short EXACT substring from the source text that supports it.
-- For inferred values, cite the text used to infer it or output 'INFERRED FROM TEXT'
+- You must ANNOTATE every value with the MOST RELEVANT short EXACT substring from the source text that supports it.
+- For inferred values, cite the text used to infer it in the matching_text field or output 'INFERRED FROM TEXT'
 - If no support exists, output 'INSUFFICIENT DATA' and leave value__ null or '', 0.0, False etc depending on the type of the field.
 `,
           matching_text:
-            'Cite the **EXACT TEXT from the SOURCE TEXT** that supports the extracted value within 120 characters. If the exact substring is >120 chars, truncate with ellipsis "...".',
+            'Cite the **MOST RELEVANT EXACT TEXT from the SOURCE TEXT** that supports the extracted value within 80 characters. If the exact substring is >80 chars, truncate with ellipsis "...". Provide only the single most relevant citation.',
           page: "Cite the page number of the source text that the extracted value is from. The page number is the integer that appears right after <<<PAGE:. If no page number is present in this format, use the default value of 1.",
         },
         scratchpad_prompt:
@@ -17748,30 +19086,15 @@ export const SupportedLLMModelNamesSchema = {
     "GPT_4_1_MINI",
     "AZURE_OPENAI_GPT_4O",
     "AZURE_OPENAI_GPT_4O_MINI",
+    "AZURE_OPENAI_GPT_4_1",
+    "AZURE_OPENAI_GPT_4_1_MINI",
+    "AZURE_OPENAI_GPT_4_1_NANO",
     "CLAUDE_3_5_SONNET",
     "BEDROCK_CLAUDE_3_5_SONNET_V1",
     "BEDROCK_CLAUDE_3_5_SONNET_V2",
     "VERTEX_AI_CLAUDE_3_5_SONNET_V2",
   ],
   title: "SupportedLLMModelNames",
-} as const;
-
-export const TextBlockSchema = {
-  properties: {
-    block_type: {
-      type: "string",
-      const: "text",
-      title: "Block Type",
-      default: "text",
-    },
-    text: {
-      type: "string",
-      title: "Text",
-    },
-  },
-  type: "object",
-  required: ["text"],
-  title: "TextBlock",
 } as const;
 
 export const TextNodeSchema = {
@@ -18045,6 +19368,8 @@ export const UsageResponseSchema = {
           "plan_spend_limit_soft_alert",
           "configured_spend_limit_exceeded",
           "free_credits_exhausted",
+          "internal_spending_alert",
+          "has_spending_alert",
         ],
       },
       type: "array",
@@ -18071,6 +19396,94 @@ export const UsageResponseSchema = {
   type: "object",
   title: "UsageResponse",
   description: "Response model",
+} as const;
+
+export const UserSchema = {
+  properties: {
+    id: {
+      type: "string",
+      title: "Id",
+    },
+    email: {
+      type: "string",
+      format: "email",
+      title: "Email",
+    },
+    last_login_provider: {
+      type: "string",
+      enum: ["oidc", "basic", "no_auth"],
+      title: "Last Login Provider",
+      description: "The last login provider.",
+      default: "oidc",
+    },
+    name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Name",
+      description: "The user's name.",
+    },
+    first_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "First Name",
+      description: "The user's first name.",
+    },
+    last_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Name",
+      description: "The user's last name.",
+    },
+    claims: {
+      $ref: "#/components/schemas/CustomClaims",
+      description: "The user's custom claims.",
+    },
+    restrict: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/Restrict",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description: "The restrictions on the user.",
+    },
+    created_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Created At",
+      description: "The user's creation date.",
+    },
+  },
+  type: "object",
+  required: ["id", "email"],
+  title: "User",
 } as const;
 
 export const UserJobRecordSchema = {
@@ -18626,6 +20039,11 @@ export const WebhookConfigurationSchema = {
               "extract.error",
               "extract.partial_success",
               "extract.cancelled",
+              "parse.pending",
+              "parse.success",
+              "parse.error",
+              "parse.partial_success",
+              "parse.cancelled",
               "unmapped_event",
             ],
           },
@@ -18638,170 +20056,22 @@ export const WebhookConfigurationSchema = {
       title: "Webhook Events",
       description: "List of event names to subscribe to",
     },
+    webhook_output_format: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Webhook Output Format",
+      description:
+        "The output format to use for the webhook. Defaults to string if none supplied. Currently supported values: string, json",
+    },
   },
   type: "object",
   title: "WebhookConfiguration",
   description:
     "Allows the user to configure webhook options for notifications and callbacks.",
-} as const;
-
-export const StatelessExtractionRequestSchema = {
-  type: "object",
-  required: ["data_schema"],
-  properties: {
-    data_schema: {
-      anyOf: [
-        {
-          additionalProperties: {
-            anyOf: [
-              {
-                additionalProperties: true,
-                type: "object",
-              },
-              {
-                items: {},
-                type: "array",
-              },
-              {
-                type: "string",
-              },
-              {
-                type: "integer",
-              },
-              {
-                type: "number",
-              },
-              {
-                type: "boolean",
-              },
-              {
-                type: "null",
-              },
-            ],
-          },
-          type: "object",
-        },
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    config: {
-      $ref: "#/components/schemas/ExtractConfig",
-      description: "The configuration parameters for the extraction agent.",
-    },
-    file_id: {
-      type: "string",
-      format: "uuid",
-      title: "File Id",
-      description: "ID of an uploaded file to extract from",
-    },
-  },
-  title: "StatelessExtractionRequest",
-  description:
-    "Request body for stateless extraction. Must include either file_id, text, or base64.",
-} as const;
-
-export const llama_index__core__base__llms__types__ChatMessageSchema = {
-  properties: {
-    role: {
-      $ref: "#/components/schemas/MessageRole",
-      default: "user",
-    },
-    additional_kwargs: {
-      additionalProperties: true,
-      type: "object",
-      title: "Additional Kwargs",
-    },
-    blocks: {
-      items: {
-        oneOf: [
-          {
-            $ref: "#/components/schemas/TextBlock",
-          },
-          {
-            $ref: "#/components/schemas/ImageBlock",
-          },
-          {
-            $ref: "#/components/schemas/AudioBlock",
-          },
-          {
-            $ref: "#/components/schemas/DocumentBlock",
-          },
-        ],
-        discriminator: {
-          propertyName: "block_type",
-          mapping: {
-            audio: "#/components/schemas/AudioBlock",
-            document: "#/components/schemas/DocumentBlock",
-            image: "#/components/schemas/ImageBlock",
-            text: "#/components/schemas/TextBlock",
-          },
-        },
-      },
-      type: "array",
-      title: "Blocks",
-    },
-  },
-  type: "object",
-  title: "ChatMessage",
-  description: "Chat message.",
-} as const;
-
-export const src__app__schema__chat__ChatMessageSchema = {
-  properties: {
-    id: {
-      type: "string",
-      format: "uuid",
-      title: "Id",
-    },
-    index: {
-      type: "integer",
-      title: "Index",
-      description: "The index of the message in the chat.",
-    },
-    annotations: {
-      items: {
-        $ref: "#/components/schemas/MessageAnnotation",
-      },
-      type: "array",
-      title: "Annotations",
-      description: "Retrieval annotations for the message.",
-    },
-    role: {
-      $ref: "#/components/schemas/MessageRole",
-      description: "The role of the message.",
-    },
-    content: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Content",
-      description: "Text content of the generation",
-    },
-    additional_kwargs: {
-      additionalProperties: {
-        type: "string",
-      },
-      type: "object",
-      title: "Additional Kwargs",
-      description: "Additional arguments passed to the model",
-    },
-    class_name: {
-      type: "string",
-      title: "Class Name",
-      default: "base_component",
-    },
-  },
-  type: "object",
-  required: ["id", "index", "role"],
-  title: "ChatMessage",
 } as const;

--- a/ts/llama_cloud_services/src/client/sdk.gen.ts
+++ b/ts/llama_cloud_services/src/client/sdk.gen.ts
@@ -7,6 +7,12 @@ import {
   formDataBodySerializer,
 } from "@hey-api/client-fetch";
 import type {
+  ListDeploymentsApiV1ProjectsProjectIdAgentsGetData,
+  ListDeploymentsApiV1ProjectsProjectIdAgentsGetResponse,
+  ListDeploymentsApiV1ProjectsProjectIdAgentsGetError,
+  SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostData,
+  SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponse,
+  SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostError,
   ListKeysApiV1ApiKeysGetData,
   ListKeysApiV1ApiKeysGetResponse,
   ListKeysApiV1ApiKeysGetError,
@@ -16,9 +22,6 @@ import type {
   DeleteApiKeyApiV1ApiKeysApiKeyIdDeleteData,
   DeleteApiKeyApiV1ApiKeysApiKeyIdDeleteResponse,
   DeleteApiKeyApiV1ApiKeysApiKeyIdDeleteError,
-  UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutData,
-  UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutResponse,
-  UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutError,
   ValidateEmbeddingConnectionApiV1ValidateIntegrationsValidateEmbeddingConnectionPostData,
   ValidateEmbeddingConnectionApiV1ValidateIntegrationsValidateEmbeddingConnectionPostResponse,
   ValidateEmbeddingConnectionApiV1ValidateIntegrationsValidateEmbeddingConnectionPostError,
@@ -195,6 +198,12 @@ import type {
   ListFilePageFiguresApiV1FilesIdPageFiguresPageIndexGetError,
   GetFilePageFigureApiV1FilesIdPageFiguresPageIndexFigureNameGetData,
   GetFilePageFigureApiV1FilesIdPageFiguresPageIndexFigureNameGetError,
+  GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostData,
+  GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostResponse,
+  GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostError,
+  GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostData,
+  GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostResponse,
+  GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostError,
   SearchPipelinesApiV1PipelinesGetData,
   SearchPipelinesApiV1PipelinesGetResponse,
   SearchPipelinesApiV1PipelinesGetError,
@@ -308,9 +317,13 @@ import type {
   GetPipelineDocumentStatusApiV1PipelinesPipelineIdDocumentsDocumentIdStatusGetData,
   GetPipelineDocumentStatusApiV1PipelinesPipelineIdDocumentsDocumentIdStatusGetResponse,
   GetPipelineDocumentStatusApiV1PipelinesPipelineIdDocumentsDocumentIdStatusGetError,
+  SyncPipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdSyncPostData,
+  SyncPipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdSyncPostError,
   ListPipelineDocumentChunksApiV1PipelinesPipelineIdDocumentsDocumentIdChunksGetData,
   ListPipelineDocumentChunksApiV1PipelinesPipelineIdDocumentsDocumentIdChunksGetResponse,
   ListPipelineDocumentChunksApiV1PipelinesPipelineIdDocumentsDocumentIdChunksGetError,
+  ForceSyncAllPipelineDocumentsApiV1PipelinesPipelineIdDocumentsForceSyncAllPostData,
+  ForceSyncAllPipelineDocumentsApiV1PipelinesPipelineIdDocumentsForceSyncAllPostError,
   ListRetrieversApiV1RetrieversGetData,
   ListRetrieversApiV1RetrieversGetResponse,
   ListRetrieversApiV1RetrieversGetError,
@@ -408,15 +421,21 @@ import type {
   UpdateChatAppApiV1AppsIdPutError,
   ChatWithChatAppApiV1AppsIdChatPostData,
   ChatWithChatAppApiV1AppsIdChatPostError,
-  ListDeploymentsApiV1ProjectsProjectIdAgentsGetData,
-  ListDeploymentsApiV1ProjectsProjectIdAgentsGetResponse,
-  ListDeploymentsApiV1ProjectsProjectIdAgentsGetError,
-  SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostData,
-  SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponse,
-  SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostError,
-  ClassifyDocumentsApiV1ClassifierClassifyPostData,
-  ClassifyDocumentsApiV1ClassifierClassifyPostResponse,
-  ClassifyDocumentsApiV1ClassifierClassifyPostError,
+  ListClassifyJobsApiV1ClassifierJobsGetData,
+  ListClassifyJobsApiV1ClassifierJobsGetResponse,
+  ListClassifyJobsApiV1ClassifierJobsGetError,
+  CreateClassifyJobApiV1ClassifierJobsPostData,
+  CreateClassifyJobApiV1ClassifierJobsPostResponse,
+  CreateClassifyJobApiV1ClassifierJobsPostError,
+  GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetData,
+  GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetResponse,
+  GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetError,
+  GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetData,
+  GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetResponse,
+  GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetError,
+  ReadSelfApiV1AuthMeGetData,
+  ReadSelfApiV1AuthMeGetResponse,
+  ReadSelfApiV1AuthMeGetError,
   CreateCustomerPortalSessionApiV1BillingCustomerPortalSessionPostData,
   CreateCustomerPortalSessionApiV1BillingCustomerPortalSessionPostResponse,
   CreateCustomerPortalSessionApiV1BillingCustomerPortalSessionPostError,
@@ -444,6 +463,9 @@ import type {
   GetExtractionAgentByNameApiV1ExtractionExtractionAgentsByNameNameGetData,
   GetExtractionAgentByNameApiV1ExtractionExtractionAgentsByNameNameGetResponse,
   GetExtractionAgentByNameApiV1ExtractionExtractionAgentsByNameNameGetError,
+  GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetData,
+  GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetResponse,
+  GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetError,
   DeleteExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentIdDeleteData,
   DeleteExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentIdDeleteError,
   GetExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentIdGetData,
@@ -452,9 +474,6 @@ import type {
   UpdateExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentIdPutData,
   UpdateExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentIdPutResponse,
   UpdateExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentIdPutError,
-  ExtractStatelessApiV1ExtractionRunPostData,
-  ExtractStatelessApiV1ExtractionRunPostResponse,
-  ExtractStatelessApiV1ExtractionRunPostError,
   ListJobsApiV1ExtractionJobsGetData,
   ListJobsApiV1ExtractionJobsGetResponse,
   ListJobsApiV1ExtractionJobsGetError,
@@ -490,40 +509,21 @@ import type {
   GetRunApiV1ExtractionRunsRunIdGetData,
   GetRunApiV1ExtractionRunsRunIdGetResponse,
   GetRunApiV1ExtractionRunsRunIdGetError,
-  CreateReportApiV1ReportsPostData,
-  CreateReportApiV1ReportsPostResponse,
-  CreateReportApiV1ReportsPostError,
-  ListReportsApiV1ReportsListGetData,
-  ListReportsApiV1ReportsListGetResponse,
-  ListReportsApiV1ReportsListGetError,
-  DeleteReportApiV1ReportsReportIdDeleteData,
-  DeleteReportApiV1ReportsReportIdDeleteError,
-  GetReportApiV1ReportsReportIdGetData,
-  GetReportApiV1ReportsReportIdGetResponse,
-  GetReportApiV1ReportsReportIdGetError,
-  UpdateReportApiV1ReportsReportIdPatchData,
-  UpdateReportApiV1ReportsReportIdPatchResponse,
-  UpdateReportApiV1ReportsReportIdPatchError,
-  UpdateReportMetadataApiV1ReportsReportIdPostData,
-  UpdateReportMetadataApiV1ReportsReportIdPostResponse,
-  UpdateReportMetadataApiV1ReportsReportIdPostError,
-  GetReportPlanApiV1ReportsReportIdPlanGetData,
-  GetReportPlanApiV1ReportsReportIdPlanGetResponse,
-  GetReportPlanApiV1ReportsReportIdPlanGetError,
-  UpdateReportPlanApiV1ReportsReportIdPlanPatchData,
-  UpdateReportPlanApiV1ReportsReportIdPlanPatchResponse,
-  UpdateReportPlanApiV1ReportsReportIdPlanPatchError,
-  GetReportEventsApiV1ReportsReportIdEventsGetData,
-  GetReportEventsApiV1ReportsReportIdEventsGetResponse,
-  GetReportEventsApiV1ReportsReportIdEventsGetError,
-  GetReportMetadataApiV1ReportsReportIdMetadataGetData,
-  GetReportMetadataApiV1ReportsReportIdMetadataGetResponse,
-  GetReportMetadataApiV1ReportsReportIdMetadataGetError,
-  SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostData,
-  SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostResponse,
-  SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostError,
-  RestartReportApiV1ReportsReportIdRestartPostData,
-  RestartReportApiV1ReportsReportIdRestartPostError,
+  ExtractStatelessApiV1ExtractionRunPostData,
+  ExtractStatelessApiV1ExtractionRunPostResponse,
+  ExtractStatelessApiV1ExtractionRunPostError,
+  ListApiKeysApiV1BetaApiKeysGetData,
+  ListApiKeysApiV1BetaApiKeysGetResponse,
+  ListApiKeysApiV1BetaApiKeysGetError,
+  CreateApiKeyApiV1BetaApiKeysPostData,
+  CreateApiKeyApiV1BetaApiKeysPostResponse,
+  CreateApiKeyApiV1BetaApiKeysPostError,
+  DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteData,
+  DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteResponse,
+  DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteError,
+  GetApiKeyApiV1BetaApiKeysApiKeyIdGetData,
+  GetApiKeyApiV1BetaApiKeysApiKeyIdGetResponse,
+  GetApiKeyApiV1BetaApiKeysApiKeyIdGetError,
   ListBatchesApiV1BetaBatchesGetData,
   ListBatchesApiV1BetaBatchesGetResponse,
   ListBatchesApiV1BetaBatchesGetError,
@@ -551,6 +551,48 @@ import type {
   AggregateAgentDataApiV1BetaAgentDataAggregatePostData,
   AggregateAgentDataApiV1BetaAgentDataAggregatePostResponse,
   AggregateAgentDataApiV1BetaAgentDataAggregatePostError,
+  ListQuotaConfigurationsApiV1BetaQuotaManagementGetData,
+  ListQuotaConfigurationsApiV1BetaQuotaManagementGetResponse,
+  ListQuotaConfigurationsApiV1BetaQuotaManagementGetError,
+  CreateFileApiV1BetaFilesPostData,
+  CreateFileApiV1BetaFilesPostResponse,
+  CreateFileApiV1BetaFilesPostError,
+  UpsertFileApiV1BetaFilesPutData,
+  UpsertFileApiV1BetaFilesPutResponse,
+  UpsertFileApiV1BetaFilesPutError,
+  QueryFilesApiV1BetaFilesQueryPostData,
+  QueryFilesApiV1BetaFilesQueryPostResponse,
+  QueryFilesApiV1BetaFilesQueryPostError,
+  DeleteFileApiV1BetaFilesFileIdDeleteData,
+  DeleteFileApiV1BetaFilesFileIdDeleteResponse,
+  DeleteFileApiV1BetaFilesFileIdDeleteError,
+  ListParseConfigurationsApiV1BetaParseConfigurationsGetData,
+  ListParseConfigurationsApiV1BetaParseConfigurationsGetResponse,
+  ListParseConfigurationsApiV1BetaParseConfigurationsGetError,
+  CreateParseConfigurationApiV1BetaParseConfigurationsPostData,
+  CreateParseConfigurationApiV1BetaParseConfigurationsPostResponse,
+  CreateParseConfigurationApiV1BetaParseConfigurationsPostError,
+  UpsertParseConfigurationApiV1BetaParseConfigurationsPutData,
+  UpsertParseConfigurationApiV1BetaParseConfigurationsPutResponse,
+  UpsertParseConfigurationApiV1BetaParseConfigurationsPutError,
+  DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteData,
+  DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteResponse,
+  DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteError,
+  GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetData,
+  GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetResponse,
+  GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetError,
+  UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutData,
+  UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutResponse,
+  UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutError,
+  QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostData,
+  QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostResponse,
+  QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostError,
+  GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetData,
+  GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetResponse,
+  GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetError,
+  UploadFileV2ApiV2Alpha1ParseUploadPostData,
+  UploadFileV2ApiV2Alpha1ParseUploadPostResponse,
+  UploadFileV2ApiV2Alpha1ParseUploadPostError,
   GetJobImageResultApiParsingJobJobIdResultImageNameGetData,
   GetJobImageResultApiParsingJobJobIdResultImageNameGetError,
   GetSupportedFileExtensionsApiParsingSupportedFileExtensionsGetData,
@@ -623,8 +665,64 @@ export type Options<
 };
 
 /**
+ * List Deployments
+ * List all deployments for a project.
+ */
+export const listDeploymentsApiV1ProjectsProjectIdAgentsGet = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    ListDeploymentsApiV1ProjectsProjectIdAgentsGetData,
+    ThrowOnError
+  >,
+) => {
+  return (options.client ?? _heyApiClient).get<
+    ListDeploymentsApiV1ProjectsProjectIdAgentsGetResponse,
+    ListDeploymentsApiV1ProjectsProjectIdAgentsGetError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/projects/{project_id}/agents",
+    ...options,
+  });
+};
+
+/**
+ * Sync Deployments
+ * Sync deployments for a project.
+ */
+export const syncDeploymentsApiV1ProjectsProjectIdAgentsSyncPost = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostData,
+    ThrowOnError
+  >,
+) => {
+  return (options.client ?? _heyApiClient).post<
+    SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponse,
+    SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/projects/{project_id}/agents:sync",
+    ...options,
+  });
+};
+
+/**
  * List Keys
- * List API Keys for a user.
+ * List API Keys for a user, filtered by type.
  */
 export const listKeysApiV1ApiKeysGet = <ThrowOnError extends boolean = false>(
   options?: Options<ListKeysApiV1ApiKeysGetData, ThrowOnError>,
@@ -635,10 +733,6 @@ export const listKeysApiV1ApiKeysGet = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -664,10 +758,6 @@ export const generateKeyApiV1ApiKeysPost = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -701,49 +791,9 @@ export const deleteApiKeyApiV1ApiKeysApiKeyIdDelete = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/api-keys/{api_key_id}",
     ...options,
-  });
-};
-
-/**
- * Update Existing Api Key
- * Update name of an existing API Key.
- */
-export const updateExistingApiKeyApiV1ApiKeysApiKeyIdPut = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutData,
-    ThrowOnError
-  >,
-) => {
-  return (options.client ?? _heyApiClient).put<
-    UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutResponse,
-    UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutError,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/api/v1/api-keys/{api_key_id}",
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
   });
 };
 
@@ -773,10 +823,6 @@ export const validateEmbeddingConnectionApiV1ValidateIntegrationsValidateEmbeddi
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -812,10 +858,6 @@ export const validateDataSourceConnectionApiV1ValidateIntegrationsValidateDataSo
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/validate-integrations/validate-data-source-connection",
       ...options,
@@ -843,10 +885,6 @@ export const validateDataSinkConnectionApiV1ValidateIntegrationsValidateDataSink
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -979,10 +1017,6 @@ export const deleteDataSinkApiV1DataSinksDataSinkIdDelete = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/data-sinks/{data_sink_id}",
     ...options,
@@ -1008,10 +1042,6 @@ export const getDataSinkApiV1DataSinksDataSinkIdGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/data-sinks/{data_sink_id}",
     ...options,
@@ -1033,10 +1063,6 @@ export const updateDataSinkApiV1DataSinksDataSinkIdPut = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -1170,10 +1196,6 @@ export const deleteDataSourceApiV1DataSourcesDataSourceIdDelete = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/data-sources/{data_source_id}",
     ...options,
@@ -1202,10 +1224,6 @@ export const getDataSourceApiV1DataSourcesDataSourceIdGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/data-sources/{data_source_id}",
     ...options,
@@ -1230,10 +1248,6 @@ export const updateDataSourceApiV1DataSourcesDataSourceIdPut = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -1437,10 +1451,6 @@ export const listOrganizationsApiV1OrganizationsGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/organizations",
     ...options,
@@ -1462,10 +1472,6 @@ export const createOrganizationApiV1OrganizationsPost = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -1495,10 +1501,6 @@ export const upsertOrganizationApiV1OrganizationsPut = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -1535,10 +1537,6 @@ export const getDefaultOrganizationApiV1OrganizationsDefaultGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/organizations/default",
     ...options,
@@ -1563,10 +1561,6 @@ export const setDefaultOrganizationApiV1OrganizationsDefaultPut = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -1603,10 +1597,6 @@ export const deleteOrganizationApiV1OrganizationsOrganizationIdDelete = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/organizations/{organization_id}",
     ...options,
@@ -1635,10 +1625,6 @@ export const getOrganizationApiV1OrganizationsOrganizationIdGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/organizations/{organization_id}",
     ...options,
@@ -1663,10 +1649,6 @@ export const updateOrganizationApiV1OrganizationsOrganizationIdPut = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -1703,10 +1685,6 @@ export const getOrganizationUsageApiV1OrganizationsOrganizationIdUsageGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/organizations/{organization_id}/usage",
     ...options,
@@ -1731,10 +1709,6 @@ export const listOrganizationUsersApiV1OrganizationsOrganizationIdUsersGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -1767,10 +1741,6 @@ export const addUsersToOrganizationApiV1OrganizationsOrganizationIdUsersPut = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/organizations/{organization_id}/users",
     ...options,
@@ -1798,10 +1768,6 @@ export const removeUsersFromOrganizationApiV1OrganizationsOrganizationIdUsersMem
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -1838,10 +1804,6 @@ export const batchRemoveUsersFromOrganizationApiV1OrganizationsOrganizationIdUse
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/organizations/{organization_id}/users/remove",
       ...options,
@@ -1874,10 +1836,6 @@ export const listRolesApiV1OrganizationsOrganizationIdRolesGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/organizations/{organization_id}/roles",
     ...options,
@@ -1902,10 +1860,6 @@ export const getUserRoleApiV1OrganizationsOrganizationIdUsersRolesGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -1937,10 +1891,6 @@ export const assignRoleToUserInOrganizationApiV1OrganizationsOrganizationIdUsers
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/organizations/{organization_id}/users/roles",
       ...options,
@@ -1968,10 +1918,6 @@ export const listProjectsByUserApiV1OrganizationsOrganizationIdUsersUserIdProjec
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -2034,10 +1980,6 @@ export const removeUserFromProjectApiV1OrganizationsOrganizationIdUsersUserIdPro
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/organizations/{organization_id}/users/{user_id}/projects/{project_id}",
       ...options,
@@ -2063,10 +2005,6 @@ export const listProjectsApiV1ProjectsGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/projects",
     ...options,
@@ -2088,10 +2026,6 @@ export const createProjectApiV1ProjectsPost = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -2122,10 +2056,6 @@ export const upsertProjectApiV1ProjectsPut = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -2413,6 +2343,9 @@ export const uploadFileApiV1FilesPost = <ThrowOnError extends boolean = false>(
 /**
  * Generate Presigned Url
  * Create a presigned url for uploading a file.
+ *
+ * The presigned url is valid for a limited time period, after which it will expire.
+ * Be careful on accidental exposure of the presigned url, as it may allow unauthorized access to the file before the expiration.
  */
 export const generatePresignedUrlApiV1FilesPut = <
   ThrowOnError extends boolean = false,
@@ -2702,6 +2635,74 @@ export const getFilePageFigureApiV1FilesIdPageFiguresPageIndexFigureNameGet = <
 };
 
 /**
+ * Generate File Page Screenshot Presigned Url
+ * Returns a presigned url to read a page screenshot.
+ *
+ * The presigned url is valid for a limited time period, after which it will expire.
+ * Be careful on accidental exposure of the presigned url, as it may allow unauthorized access to the file before the expiration.
+ */
+export const generateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPost =
+  <ThrowOnError extends boolean = false>(
+    options: Options<
+      GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostData,
+      ThrowOnError
+    >,
+  ) => {
+    return (options.client ?? _heyApiClient).post<
+      GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostResponse,
+      GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostError,
+      ThrowOnError
+    >({
+      security: [
+        {
+          scheme: "bearer",
+          type: "http",
+        },
+        {
+          scheme: "bearer",
+          type: "http",
+        },
+      ],
+      url: "/api/v1/files/{id}/page_screenshots/{page_index}/presigned_url",
+      ...options,
+    });
+  };
+
+/**
+ * Generate File Page Figure Presigned Url
+ * Returns a presigned url to read a page figure.
+ *
+ * The presigned url is valid for a limited time period, after which it will expire.
+ * Be careful on accidental exposure of the presigned url, as it may allow unauthorized access to the file before the expiration.
+ */
+export const generateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPost =
+  <ThrowOnError extends boolean = false>(
+    options: Options<
+      GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostData,
+      ThrowOnError
+    >,
+  ) => {
+    return (options.client ?? _heyApiClient).post<
+      GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostResponse,
+      GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostError,
+      ThrowOnError
+    >({
+      security: [
+        {
+          scheme: "bearer",
+          type: "http",
+        },
+        {
+          scheme: "bearer",
+          type: "http",
+        },
+      ],
+      url: "/api/v1/files/{id}/page-figures/{page_index}/{figure_name}/presigned_url",
+      ...options,
+    });
+  };
+
+/**
  * Search Pipelines
  * Search for pipelines by various parameters.
  */
@@ -2819,10 +2820,6 @@ export const deletePipelineApiV1PipelinesPipelineIdDelete = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/pipelines/{pipeline_id}",
     ...options,
@@ -2844,10 +2841,6 @@ export const getPipelineApiV1PipelinesPipelineIdGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -2876,10 +2869,6 @@ export const updateExistingPipelineApiV1PipelinesPipelineIdPut = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -2916,10 +2905,6 @@ export const getPipelineStatusApiV1PipelinesPipelineIdStatusGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/pipelines/{pipeline_id}/status",
     ...options,
@@ -2944,10 +2929,6 @@ export const syncPipelineApiV1PipelinesPipelineIdSyncPost = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -2979,10 +2960,6 @@ export const cancelPipelineSyncApiV1PipelinesPipelineIdSyncCancelPost = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/pipelines/{pipeline_id}/sync/cancel",
     ...options,
@@ -3006,10 +2983,6 @@ export const forceDeletePipelineApiV1PipelinesPipelineIdForceDeletePost = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -3038,10 +3011,6 @@ export const copyPipelineApiV1PipelinesPipelineIdCopyPost = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -3075,10 +3044,6 @@ export const listPipelineFilesApiV1PipelinesPipelineIdFilesGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/pipelines/{pipeline_id}/files",
     ...options,
@@ -3107,10 +3072,6 @@ export const addFilesToPipelineApiApiV1PipelinesPipelineIdFilesPut = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/pipelines/{pipeline_id}/files",
     ...options,
@@ -3125,6 +3086,15 @@ export const addFilesToPipelineApiApiV1PipelinesPipelineIdFilesPut = <
  * @deprecated
  * List Pipeline Files2
  * Get files for a pipeline.
+ *
+ * Args:
+ * pipeline_id: ID of the pipeline
+ * data_source_id: Optional filter by data source ID
+ * only_manually_uploaded: Filter for only manually uploaded files
+ * file_name_contains: Optional filter by file name (substring match)
+ * limit: Limit number of results
+ * offset: Offset for pagination
+ * order_by: Field to order by
  */
 export const listPipelineFiles2ApiV1PipelinesPipelineIdFiles2Get = <
   ThrowOnError extends boolean = false,
@@ -3140,10 +3110,6 @@ export const listPipelineFiles2ApiV1PipelinesPipelineIdFiles2Get = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -3175,10 +3141,6 @@ export const getPipelineFileStatusCountsApiV1PipelinesPipelineIdFilesStatusCount
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/pipelines/{pipeline_id}/files/status-counts",
       ...options,
@@ -3202,10 +3164,6 @@ export const getPipelineFileStatusApiV1PipelinesPipelineIdFilesFileIdStatusGet =
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -3238,10 +3196,6 @@ export const deletePipelineFileApiV1PipelinesPipelineIdFilesFileIdDelete = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/pipelines/{pipeline_id}/files/{file_id}",
     ...options,
@@ -3266,10 +3220,6 @@ export const updatePipelineFileApiV1PipelinesPipelineIdFilesFileIdPut = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -3305,10 +3255,6 @@ export const deletePipelineFilesMetadataApiV1PipelinesPipelineIdMetadataDelete =
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/pipelines/{pipeline_id}/metadata",
       ...options,
@@ -3334,10 +3280,6 @@ export const importPipelineMetadataApiV1PipelinesPipelineIdMetadataPut = <
   >({
     ...formDataBodySerializer,
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -3374,10 +3316,6 @@ export const listPipelineDataSourcesApiV1PipelinesPipelineIdDataSourcesGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/pipelines/{pipeline_id}/data-sources",
     ...options,
@@ -3402,10 +3340,6 @@ export const addDataSourcesToPipelineApiV1PipelinesPipelineIdDataSourcesPut = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -3441,10 +3375,6 @@ export const deletePipelineDataSourceApiV1PipelinesPipelineIdDataSourcesDataSour
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/pipelines/{pipeline_id}/data-sources/{data_source_id}",
       ...options,
@@ -3468,10 +3398,6 @@ export const updatePipelineDataSourceApiV1PipelinesPipelineIdDataSourcesDataSour
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -3507,10 +3433,6 @@ export const syncPipelineDataSourceApiV1PipelinesPipelineIdDataSourcesDataSource
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/pipelines/{pipeline_id}/data-sources/{data_source_id}/sync",
       ...options,
@@ -3534,10 +3456,6 @@ export const getPipelineDataSourceStatusApiV1PipelinesPipelineIdDataSourcesDataS
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -3606,10 +3524,6 @@ export const listPipelineJobsApiV1PipelinesPipelineIdJobsGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/pipelines/{pipeline_id}/jobs",
     ...options,
@@ -3634,10 +3548,6 @@ export const getPipelineJobApiV1PipelinesPipelineIdJobsJobIdGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -3669,10 +3579,6 @@ export const getPlaygroundSessionApiV1PipelinesPipelineIdPlaygroundSessionGet =
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/pipelines/{pipeline_id}/playground-session",
       ...options,
@@ -3694,10 +3600,6 @@ export const chatApiV1PipelinesPipelineIdChatPost = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -3734,10 +3636,6 @@ export const listPipelineDocumentsApiV1PipelinesPipelineIdDocumentsGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/pipelines/{pipeline_id}/documents",
     ...options,
@@ -3761,10 +3659,6 @@ export const createBatchPipelineDocumentsApiV1PipelinesPipelineIdDocumentsPost =
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -3800,10 +3694,6 @@ export const upsertBatchPipelineDocumentsApiV1PipelinesPipelineIdDocumentsPut =
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/pipelines/{pipeline_id}/documents",
       ...options,
@@ -3831,10 +3721,6 @@ export const paginatedListPipelineDocumentsApiV1PipelinesPipelineIdDocumentsPagi
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -3869,10 +3755,6 @@ export const deletePipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdDe
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/pipelines/{pipeline_id}/documents/{document_id}",
       ...options,
@@ -3896,10 +3778,6 @@ export const getPipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdGet =
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -3931,12 +3809,35 @@ export const getPipelineDocumentStatusApiV1PipelinesPipelineIdDocumentsDocumentI
           scheme: "bearer",
           type: "http",
         },
+      ],
+      url: "/api/v1/pipelines/{pipeline_id}/documents/{document_id}/status",
+      ...options,
+    });
+  };
+
+/**
+ * Sync Pipeline Document
+ * Sync a specific document for a pipeline.
+ */
+export const syncPipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdSyncPost =
+  <ThrowOnError extends boolean = false>(
+    options: Options<
+      SyncPipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdSyncPostData,
+      ThrowOnError
+    >,
+  ) => {
+    return (options.client ?? _heyApiClient).post<
+      unknown,
+      SyncPipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdSyncPostError,
+      ThrowOnError
+    >({
+      security: [
         {
           scheme: "bearer",
           type: "http",
         },
       ],
-      url: "/api/v1/pipelines/{pipeline_id}/documents/{document_id}/status",
+      url: "/api/v1/pipelines/{pipeline_id}/documents/{document_id}/sync",
       ...options,
     });
   };
@@ -3962,12 +3863,38 @@ export const listPipelineDocumentChunksApiV1PipelinesPipelineIdDocumentsDocument
           scheme: "bearer",
           type: "http",
         },
+      ],
+      url: "/api/v1/pipelines/{pipeline_id}/documents/{document_id}/chunks",
+      ...options,
+    });
+  };
+
+/**
+ * Force Sync All Pipeline Documents
+ * Force sync all documents in a pipeline by batching document ingestion jobs.
+ *
+ * - Iterates all document refs for the pipeline
+ * - Enqueues document ingestion jobs in batches of `batch_size`
+ */
+export const forceSyncAllPipelineDocumentsApiV1PipelinesPipelineIdDocumentsForceSyncAllPost =
+  <ThrowOnError extends boolean = false>(
+    options: Options<
+      ForceSyncAllPipelineDocumentsApiV1PipelinesPipelineIdDocumentsForceSyncAllPostData,
+      ThrowOnError
+    >,
+  ) => {
+    return (options.client ?? _heyApiClient).post<
+      unknown,
+      ForceSyncAllPipelineDocumentsApiV1PipelinesPipelineIdDocumentsForceSyncAllPostError,
+      ThrowOnError
+    >({
+      security: [
         {
           scheme: "bearer",
           type: "http",
         },
       ],
-      url: "/api/v1/pipelines/{pipeline_id}/documents/{document_id}/chunks",
+      url: "/api/v1/pipelines/{pipeline_id}/documents/force-sync-all",
       ...options,
     });
   };
@@ -4089,10 +4016,6 @@ export const deleteRetrieverApiV1RetrieversRetrieverIdDelete = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/retrievers/{retriever_id}",
     ...options,
@@ -4146,10 +4069,6 @@ export const updateRetrieverApiV1RetrieversRetrieverIdPut = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -4259,7 +4178,7 @@ export const getJobsApiV1JobsGet = <ThrowOnError extends boolean = false>(
         type: "http",
       },
     ],
-    url: "/api/v1/jobs/",
+    url: "/api/v1/jobs",
     ...options,
   });
 };
@@ -4279,10 +4198,6 @@ export const listSupportedModelsApiV1EvalsModelsGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -4311,10 +4226,6 @@ export const getJobImageResultApiV1ParsingJobJobIdResultImageNameGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -4431,10 +4342,6 @@ export const getJobApiV1ParsingJobJobIdGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/parsing/job/{job_id}",
     ...options,
@@ -4463,10 +4370,6 @@ export const getJobParametersApiV1ParsingJobJobIdParametersGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/parsing/job/{job_id}/parameters",
     ...options,
@@ -4491,10 +4394,6 @@ export const getParsingJobDetailsApiV1ParsingJobJobIdDetailsGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -4530,10 +4429,6 @@ export const getJobTextResultApiV1ParsingJobJobIdResultTextGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/parsing/job/{job_id}/result/text",
     ...options,
@@ -4558,10 +4453,6 @@ export const getJobRawTextResultRawApiV1ParsingJobJobIdResultRawTextGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -4594,10 +4485,6 @@ export const getJobRawTextResultApiV1ParsingJobJobIdResultPdfGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/parsing/job/{job_id}/result/pdf",
     ...options,
@@ -4622,10 +4509,6 @@ export const getJobRawTextResultRawPdfApiV1ParsingJobJobIdResultRawPdfGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -4661,10 +4544,6 @@ export const getJobStructuredResultApiV1ParsingJobJobIdResultStructuredGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/parsing/job/{job_id}/result/structured",
     ...options,
@@ -4688,10 +4567,6 @@ export const getJobRawStructuredResultApiV1ParsingJobJobIdResultRawStructuredGet
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -4724,10 +4599,6 @@ export const getJobRawXlsxResultApiV1ParsingJobJobIdResultXlsxGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/parsing/job/{job_id}/result/xlsx",
     ...options,
@@ -4752,10 +4623,6 @@ export const getJobRawXlsxResultRawApiV1ParsingJobJobIdResultRawXlsxGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -4791,10 +4658,6 @@ export const getJobResultApiV1ParsingJobJobIdResultMarkdownGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/parsing/job/{job_id}/result/markdown",
     ...options,
@@ -4819,10 +4682,6 @@ export const getJobRawMdResultApiV1ParsingJobJobIdResultRawMarkdownGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -4858,10 +4717,6 @@ export const getJobJsonResultApiV1ParsingJobJobIdResultJsonGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/parsing/job/{job_id}/result/json",
     ...options,
@@ -4886,10 +4741,6 @@ export const getJobJsonRawResultApiV1ParsingJobJobIdResultRawJsonGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -4926,10 +4777,6 @@ export const getParsingHistoryResultApiV1ParsingHistoryGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/parsing/history",
     ...options,
@@ -4954,10 +4801,6 @@ export const generatePresignedUrlApiV1ParsingJobJobIdReadFilenameGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -5045,10 +4888,6 @@ export const deleteChatAppApiV1AppsIdDelete = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/apps/{id}",
     ...options,
@@ -5068,10 +4907,6 @@ export const getChatAppApiV1AppsIdGet = <ThrowOnError extends boolean = false>(
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -5134,10 +4969,6 @@ export const chatWithChatAppApiV1AppsIdChatPost = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/apps/{id}/chat",
     ...options,
@@ -5149,20 +4980,85 @@ export const chatWithChatAppApiV1AppsIdChatPost = <
 };
 
 /**
- * List Deployments
- * List all deployments for a project.
+ * List Classify Jobs
+ * List classify jobs.
+ * Experimental: This endpoint is not yet ready for production use and is subject to change at any time.
  */
-export const listDeploymentsApiV1ProjectsProjectIdAgentsGet = <
+export const listClassifyJobsApiV1ClassifierJobsGet = <
+  ThrowOnError extends boolean = false,
+>(
+  options?: Options<ListClassifyJobsApiV1ClassifierJobsGetData, ThrowOnError>,
+) => {
+  return (options?.client ?? _heyApiClient).get<
+    ListClassifyJobsApiV1ClassifierJobsGetResponse,
+    ListClassifyJobsApiV1ClassifierJobsGetError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/classifier/jobs",
+    ...options,
+  });
+};
+
+/**
+ * Create Classify Job
+ * Create a classify job.
+ * Experimental: This endpoint is not yet ready for production use and is subject to change at any time.
+ */
+export const createClassifyJobApiV1ClassifierJobsPost = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<CreateClassifyJobApiV1ClassifierJobsPostData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).post<
+    CreateClassifyJobApiV1ClassifierJobsPostResponse,
+    CreateClassifyJobApiV1ClassifierJobsPostError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/classifier/jobs",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+};
+
+/**
+ * Get Classify Job
+ * Get a classify job.
+ * Experimental: This endpoint is not yet ready for production use and is subject to change at any time.
+ */
+export const getClassifyJobApiV1ClassifierJobsClassifyJobIdGet = <
   ThrowOnError extends boolean = false,
 >(
   options: Options<
-    ListDeploymentsApiV1ProjectsProjectIdAgentsGetData,
+    GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetData,
     ThrowOnError
   >,
 ) => {
   return (options.client ?? _heyApiClient).get<
-    ListDeploymentsApiV1ProjectsProjectIdAgentsGetResponse,
-    ListDeploymentsApiV1ProjectsProjectIdAgentsGetError,
+    GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetResponse,
+    GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetError,
     ThrowOnError
   >({
     security: [
@@ -5175,140 +5071,62 @@ export const listDeploymentsApiV1ProjectsProjectIdAgentsGet = <
         type: "http",
       },
     ],
-    url: "/api/v1/projects/{project_id}/agents",
+    url: "/api/v1/classifier/jobs/{classify_job_id}",
     ...options,
   });
 };
 
 /**
- * Sync Deployments
- * Sync deployments for a project.
+ * Get Classification Job Results
+ * Get the results of a classify job.
+ * Experimental: This endpoint is not yet ready for production use and is subject to change at any time.
  */
-export const syncDeploymentsApiV1ProjectsProjectIdAgentsSyncPost = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostData,
-    ThrowOnError
-  >,
-) => {
-  return (options.client ?? _heyApiClient).post<
-    SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponse,
-    SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostError,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/api/v1/projects/{project_id}/agents:sync",
-    ...options,
-  });
-};
+export const getClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGet =
+  <ThrowOnError extends boolean = false>(
+    options: Options<
+      GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetData,
+      ThrowOnError
+    >,
+  ) => {
+    return (options.client ?? _heyApiClient).get<
+      GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetResponse,
+      GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetError,
+      ThrowOnError
+    >({
+      security: [
+        {
+          scheme: "bearer",
+          type: "http",
+        },
+        {
+          scheme: "bearer",
+          type: "http",
+        },
+      ],
+      url: "/api/v1/classifier/jobs/{classify_job_id}/results",
+      ...options,
+    });
+  };
 
 /**
- * Classify Documents
- * **[BETA]** Classify documents based on provided rules - simplified classification system.
- *
- * **This is a Beta feature** - API may change based on user feedback.
- *
- * This endpoint supports:
- * - Classifying new uploaded files
- * - Classifying existing files by ID
- * - Both new files and existing file IDs in one request
- *
- * ## v0 Features:
- * - **Simplified Rules**: Only `type` and `description` fields needed
- * - **Matching Threshold**: Confidence-based classification with configurable threshold
- * - **Smart Classification**: Filename heuristics + LLM content analysis
- * - **Document Type Filtering**: Automatically filters out non-document file types
- * - **Fast Processing**: Uses LlamaParse fast mode + GPT-4.1-nano
- * - **Optimized Performance**: Parses each file only once for all rules
- *
- * ## Simplified Scoring Logic:
- * 1. **Evaluate All Rules**: Compare document against all classification rules
- * 2. **Best Match Selection**: Return the highest scoring rule above matching_threshold
- * 3. **Unknown Classification**: Return as "unknown" if no rules score above threshold
- *
- * This ensures optimal classification by:
- * - Finding the best possible match among all rules
- * - Avoiding false positives with confidence thresholds
- * - Maximizing performance with single-pass file parsing
- *
- * ## Rule Format:
- * ```json
- * [
- * {
- * "type": "invoice",
- * "description": "contains invoice number, line items, and total amount"
- * },
- * {
- * "type": "receipt",
- * "description": "purchase receipt with transaction details and payment info"
- * }
- * ]
- * ```
- *
- * ## Classification Process:
- * 1. **Metadata Heuristics** (configurable via API):
- * - **Document Type Filter**: Only process document file types (PDF, DOC, DOCX, RTF, TXT, ODT, Pages, HTML, XML, Markdown)
- * - **Filename Heuristics**: Check if rule type appears in filename
- * - **Content Analysis**: Parse document content once and use LLM for semantic matching against all rules
- * 2. **Result**: Returns type, confidence score, and matched rule information
- *
- * ## API Parameters:
- * - `matching_threshold` (0.1-0.99, default: 0.6): Minimum confidence threshold for acceptable matches
- * - `enable_metadata_heuristic` (boolean, default: true): Enable metadata-based features
- *
- * ## Supported Document Types:
- * **Text Documents**: pdf, doc, docx, rtf, txt, odt, pages
- * **Web Documents**: html, htm, xml
- * **Markup**: md, markdown
- *
- * ## Limits (Beta):
- * - Maximum 100 files per request
- * - Maximum 10 rules per request
- * - Rule descriptions: 10-500 characters
- * - Document types: 1-50 characters (alphanumeric, hyphens, underscores)
- *
- * **Beta Notice**: This API is subject to change. Please provide feedback!
+ * Read Self
  */
-export const classifyDocumentsApiV1ClassifierClassifyPost = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    ClassifyDocumentsApiV1ClassifierClassifyPostData,
-    ThrowOnError
-  >,
+export const readSelfApiV1AuthMeGet = <ThrowOnError extends boolean = false>(
+  options?: Options<ReadSelfApiV1AuthMeGetData, ThrowOnError>,
 ) => {
-  return (options.client ?? _heyApiClient).post<
-    ClassifyDocumentsApiV1ClassifierClassifyPostResponse,
-    ClassifyDocumentsApiV1ClassifierClassifyPostError,
+  return (options?.client ?? _heyApiClient).get<
+    ReadSelfApiV1AuthMeGetResponse,
+    ReadSelfApiV1AuthMeGetError,
     ThrowOnError
   >({
-    ...formDataBodySerializer,
     security: [
       {
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
-    url: "/api/v1/classifier/classify",
+    url: "/api/v1/auth/me",
     ...options,
-    headers: {
-      "Content-Type": null,
-      ...options?.headers,
-    },
   });
 };
 
@@ -5329,10 +5147,6 @@ export const createCustomerPortalSessionApiV1BillingCustomerPortalSessionPost =
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -5368,10 +5182,6 @@ export const downgradePlanApiV1BillingDowngradePlanPost = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/billing/downgrade-plan",
     ...options,
@@ -5401,10 +5211,6 @@ export const createIntentAndCustomerSessionApiV1BillingCreateIntentAndCustomerSe
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/billing/create-intent-and-customer-session",
       ...options,
@@ -5429,10 +5235,6 @@ export const getMetronomeDashboardApiV1BillingMetronomeDashboardGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -5531,10 +5333,6 @@ export const validateExtractionSchemaApiV1ExtractionExtractionAgentsSchemaValida
           scheme: "bearer",
           type: "http",
         },
-        {
-          scheme: "bearer",
-          type: "http",
-        },
       ],
       url: "/api/v1/extraction/extraction-agents/schema/validation",
       ...options,
@@ -5606,6 +5404,38 @@ export const getExtractionAgentByNameApiV1ExtractionExtractionAgentsByNameNameGe
         },
       ],
       url: "/api/v1/extraction/extraction-agents/by-name/{name}",
+      ...options,
+    });
+  };
+
+/**
+ * Get Or Create Default Extraction Agent
+ * Get or create a default extraction agent for the current project.
+ * The default agent has an empty schema and default configuration.
+ */
+export const getOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGet =
+  <ThrowOnError extends boolean = false>(
+    options?: Options<
+      GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetData,
+      ThrowOnError
+    >,
+  ) => {
+    return (options?.client ?? _heyApiClient).get<
+      GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetResponse,
+      GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetError,
+      ThrowOnError
+    >({
+      security: [
+        {
+          scheme: "bearer",
+          type: "http",
+        },
+        {
+          scheme: "bearer",
+          type: "http",
+        },
+      ],
+      url: "/api/v1/extraction/extraction-agents/default",
       ...options,
     });
   };
@@ -5705,39 +5535,6 @@ export const updateExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgent
   };
 
 /**
- * Extract Stateless
- * Stateless extraction endpoint that uses a default extraction agent in the user's default project. Requires data_schema, config, and either file_id, text, or base64 encoded file data.
- */
-export const extractStatelessApiV1ExtractionRunPost = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<ExtractStatelessApiV1ExtractionRunPostData, ThrowOnError>,
-) => {
-  return (options.client ?? _heyApiClient).post<
-    ExtractStatelessApiV1ExtractionRunPostResponse,
-    ExtractStatelessApiV1ExtractionRunPostError,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/api/v1/extraction/run",
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
-  });
-};
-
-/**
  * List Jobs
  */
 export const listJobsApiV1ExtractionJobsGet = <
@@ -5811,10 +5608,6 @@ export const getJobApiV1ExtractionJobsJobIdGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -5971,10 +5764,6 @@ export const listExtractRunsApiV1ExtractionRunsGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/v1/extraction/runs",
     ...options,
@@ -5998,10 +5787,6 @@ export const getLatestRunFromUiApiV1ExtractionRunsLatestFromUiGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -6103,21 +5888,20 @@ export const getRunApiV1ExtractionRunsRunIdGet = <
 };
 
 /**
- * @deprecated
- * Create Report
- * Create a new report.
+ * Extract Stateless
+ * Stateless extraction endpoint that uses a default extraction agent in the user's default project.
+ * Requires data_schema, config, and either file_id, text, or base64 encoded file data.
  */
-export const createReportApiV1ReportsPost = <
+export const extractStatelessApiV1ExtractionRunPost = <
   ThrowOnError extends boolean = false,
 >(
-  options: Options<CreateReportApiV1ReportsPostData, ThrowOnError>,
+  options: Options<ExtractStatelessApiV1ExtractionRunPostData, ThrowOnError>,
 ) => {
   return (options.client ?? _heyApiClient).post<
-    CreateReportApiV1ReportsPostResponse,
-    CreateReportApiV1ReportsPostError,
+    ExtractStatelessApiV1ExtractionRunPostResponse,
+    ExtractStatelessApiV1ExtractionRunPostError,
     ThrowOnError
   >({
-    ...formDataBodySerializer,
     security: [
       {
         scheme: "bearer",
@@ -6128,28 +5912,42 @@ export const createReportApiV1ReportsPost = <
         type: "http",
       },
     ],
-    url: "/api/v1/reports/",
+    url: "/api/v1/extraction/run",
     ...options,
     headers: {
-      "Content-Type": null,
+      "Content-Type": "application/json",
       ...options?.headers,
     },
   });
 };
 
 /**
- * @deprecated
- * List Reports
- * List all reports for a project.
+ * List Api Keys
+ * List API keys.
+ *
+ * If project_id is provided, validates user has access to that project.
+ * If project_id is not provided, scopes results to the current user.
+ *
+ * Args:
+ * user: Current user
+ * db: Database session
+ * page_size: Number of items per page
+ * page_token: Token for pagination
+ * name: Filter by API key name
+ * project_id: Filter by project ID
+ * key_type: Filter by key type
+ *
+ * Returns:
+ * Paginated response with API keys
  */
-export const listReportsApiV1ReportsListGet = <
+export const listApiKeysApiV1BetaApiKeysGet = <
   ThrowOnError extends boolean = false,
 >(
-  options?: Options<ListReportsApiV1ReportsListGetData, ThrowOnError>,
+  options?: Options<ListApiKeysApiV1BetaApiKeysGetData, ThrowOnError>,
 ) => {
   return (options?.client ?? _heyApiClient).get<
-    ListReportsApiV1ReportsListGetResponse,
-    ListReportsApiV1ReportsListGetError,
+    ListApiKeysApiV1BetaApiKeysGetResponse,
+    ListApiKeysApiV1BetaApiKeysGetError,
     ThrowOnError
   >({
     security: [
@@ -6157,29 +5955,74 @@ export const listReportsApiV1ReportsListGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
-    url: "/api/v1/reports/list",
+    url: "/api/v1/beta/api-keys",
     ...options,
   });
 };
 
 /**
- * @deprecated
- * Delete Report
- * Delete a report.
+ * Create Api Key
+ * Create a new API key.
+ *
+ * If project_id is specified, validates user has admin permissions for that project.
+ *
+ * Args:
+ * api_key_create: API key creation data
+ * user: Current user
+ * db: Database session
+ *
+ * Returns:
+ * The created API key with the secret key visible in redacted_api_key field
  */
-export const deleteReportApiV1ReportsReportIdDelete = <
+export const createApiKeyApiV1BetaApiKeysPost = <
   ThrowOnError extends boolean = false,
 >(
-  options: Options<DeleteReportApiV1ReportsReportIdDeleteData, ThrowOnError>,
+  options: Options<CreateApiKeyApiV1BetaApiKeysPostData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).post<
+    CreateApiKeyApiV1BetaApiKeysPostResponse,
+    CreateApiKeyApiV1BetaApiKeysPostError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/beta/api-keys",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+};
+
+/**
+ * Delete Api Key
+ * Delete an API key.
+ *
+ * If the API key belongs to a project, validates user has admin permissions for that project.
+ * If the API key has no project, validates it belongs to the current user.
+ *
+ * Args:
+ * api_key_id: The ID of the API key to delete
+ * user: Current user
+ * db: Database session
+ */
+export const deleteApiKeyApiV1BetaApiKeysApiKeyIdDelete = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteData,
+    ThrowOnError
+  >,
 ) => {
   return (options.client ?? _heyApiClient).delete<
-    unknown,
-    DeleteReportApiV1ReportsReportIdDeleteError,
+    DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteResponse,
+    DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteError,
     ThrowOnError
   >({
     security: [
@@ -6187,29 +6030,32 @@ export const deleteReportApiV1ReportsReportIdDelete = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
-    url: "/api/v1/reports/{report_id}",
+    url: "/api/v1/beta/api-keys/{api_key_id}",
     ...options,
   });
 };
 
 /**
- * @deprecated
- * Get Report
- * Get a specific report.
+ * Get Api Key
+ * Get an API key by ID.
+ *
+ * Args:
+ * api_key_id: The ID of the API key
+ * user: Current user
+ * db: Database session
+ *
+ * Returns:
+ * The API key
  */
-export const getReportApiV1ReportsReportIdGet = <
+export const getApiKeyApiV1BetaApiKeysApiKeyIdGet = <
   ThrowOnError extends boolean = false,
 >(
-  options: Options<GetReportApiV1ReportsReportIdGetData, ThrowOnError>,
+  options: Options<GetApiKeyApiV1BetaApiKeysApiKeyIdGetData, ThrowOnError>,
 ) => {
   return (options.client ?? _heyApiClient).get<
-    GetReportApiV1ReportsReportIdGetResponse,
-    GetReportApiV1ReportsReportIdGetError,
+    GetApiKeyApiV1BetaApiKeysApiKeyIdGetResponse,
+    GetApiKeyApiV1BetaApiKeysApiKeyIdGetError,
     ThrowOnError
   >({
     security: [
@@ -6217,286 +6063,8 @@ export const getReportApiV1ReportsReportIdGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
-    url: "/api/v1/reports/{report_id}",
-    ...options,
-  });
-};
-
-/**
- * @deprecated
- * Update Report
- * Update a report's content.
- */
-export const updateReportApiV1ReportsReportIdPatch = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<UpdateReportApiV1ReportsReportIdPatchData, ThrowOnError>,
-) => {
-  return (options.client ?? _heyApiClient).patch<
-    UpdateReportApiV1ReportsReportIdPatchResponse,
-    UpdateReportApiV1ReportsReportIdPatchError,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/api/v1/reports/{report_id}",
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
-  });
-};
-
-/**
- * @deprecated
- * Update Report Metadata
- * Update metadata for a report.
- */
-export const updateReportMetadataApiV1ReportsReportIdPost = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    UpdateReportMetadataApiV1ReportsReportIdPostData,
-    ThrowOnError
-  >,
-) => {
-  return (options.client ?? _heyApiClient).post<
-    UpdateReportMetadataApiV1ReportsReportIdPostResponse,
-    UpdateReportMetadataApiV1ReportsReportIdPostError,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/api/v1/reports/{report_id}",
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
-  });
-};
-
-/**
- * @deprecated
- * Get Report Plan
- * Get the plan for a report.
- */
-export const getReportPlanApiV1ReportsReportIdPlanGet = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<GetReportPlanApiV1ReportsReportIdPlanGetData, ThrowOnError>,
-) => {
-  return (options.client ?? _heyApiClient).get<
-    GetReportPlanApiV1ReportsReportIdPlanGetResponse,
-    GetReportPlanApiV1ReportsReportIdPlanGetError,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/api/v1/reports/{report_id}/plan",
-    ...options,
-  });
-};
-
-/**
- * @deprecated
- * Update Report Plan
- * Update the plan of a report, including approval, rejection, and editing.
- */
-export const updateReportPlanApiV1ReportsReportIdPlanPatch = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    UpdateReportPlanApiV1ReportsReportIdPlanPatchData,
-    ThrowOnError
-  >,
-) => {
-  return (options.client ?? _heyApiClient).patch<
-    UpdateReportPlanApiV1ReportsReportIdPlanPatchResponse,
-    UpdateReportPlanApiV1ReportsReportIdPlanPatchError,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/api/v1/reports/{report_id}/plan",
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
-  });
-};
-
-/**
- * @deprecated
- * Get Report Events
- * Get all historical events for a report.
- */
-export const getReportEventsApiV1ReportsReportIdEventsGet = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    GetReportEventsApiV1ReportsReportIdEventsGetData,
-    ThrowOnError
-  >,
-) => {
-  return (options.client ?? _heyApiClient).get<
-    GetReportEventsApiV1ReportsReportIdEventsGetResponse,
-    GetReportEventsApiV1ReportsReportIdEventsGetError,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/api/v1/reports/{report_id}/events",
-    ...options,
-  });
-};
-
-/**
- * @deprecated
- * Get Report Metadata
- * Get metadata for a report.
- */
-export const getReportMetadataApiV1ReportsReportIdMetadataGet = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    GetReportMetadataApiV1ReportsReportIdMetadataGetData,
-    ThrowOnError
-  >,
-) => {
-  return (options.client ?? _heyApiClient).get<
-    GetReportMetadataApiV1ReportsReportIdMetadataGetResponse,
-    GetReportMetadataApiV1ReportsReportIdMetadataGetError,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/api/v1/reports/{report_id}/metadata",
-    ...options,
-  });
-};
-
-/**
- * @deprecated
- * Suggest Edits Endpoint
- * Suggest edits to a report based on user query and chat history.
- */
-export const suggestEditsEndpointApiV1ReportsReportIdSuggestEditsPost = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostData,
-    ThrowOnError
-  >,
-) => {
-  return (options.client ?? _heyApiClient).post<
-    SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostResponse,
-    SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostError,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/api/v1/reports/{report_id}/suggest_edits",
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
-  });
-};
-
-/**
- * @deprecated
- * Restart Report
- * Restart a report from scratch.
- */
-export const restartReportApiV1ReportsReportIdRestartPost = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    RestartReportApiV1ReportsReportIdRestartPostData,
-    ThrowOnError
-  >,
-) => {
-  return (options.client ?? _heyApiClient).post<
-    unknown,
-    RestartReportApiV1ReportsReportIdRestartPostError,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/api/v1/reports/{report_id}/restart",
+    url: "/api/v1/beta/api-keys/{api_key_id}",
     ...options,
   });
 };
@@ -6575,10 +6143,6 @@ export const getBatchApiV1BetaBatchesBatchIdGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -6792,6 +6356,571 @@ export const aggregateAgentDataApiV1BetaAgentDataAggregatePost = <
 };
 
 /**
+ * List quota configurations
+ * Retrieve a paginated list of quota configurations with optional filtering.
+ */
+export const listQuotaConfigurationsApiV1BetaQuotaManagementGet = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    ListQuotaConfigurationsApiV1BetaQuotaManagementGetData,
+    ThrowOnError
+  >,
+) => {
+  return (options.client ?? _heyApiClient).get<
+    ListQuotaConfigurationsApiV1BetaQuotaManagementGetResponse,
+    ListQuotaConfigurationsApiV1BetaQuotaManagementGetError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/beta/quota-management",
+    ...options,
+  });
+};
+
+/**
+ * Create File
+ * Create a new file in the project.
+ *
+ * Args:
+ * file_create: File creation data
+ * project: Validated project from dependency
+ * db: Database session
+ *
+ * Returns:
+ * The created file
+ */
+export const createFileApiV1BetaFilesPost = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<CreateFileApiV1BetaFilesPostData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).post<
+    CreateFileApiV1BetaFilesPostResponse,
+    CreateFileApiV1BetaFilesPostError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/beta/files",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+};
+
+/**
+ * Upsert File
+ * Upsert a file (create or update if exists) in the project.
+ *
+ * Args:
+ * file_create: File creation/update data
+ * project: Validated project from dependency
+ * db: Database session
+ *
+ * Returns:
+ * The upserted file
+ */
+export const upsertFileApiV1BetaFilesPut = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<UpsertFileApiV1BetaFilesPutData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).put<
+    UpsertFileApiV1BetaFilesPutResponse,
+    UpsertFileApiV1BetaFilesPutError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/beta/files",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+};
+
+/**
+ * Query Files
+ * Query files with flexible filtering and pagination.
+ *
+ * Args:
+ * request: The query request with filters and pagination
+ * project: Validated project from dependency
+ * db: Database session
+ *
+ * Returns:
+ * Paginated response with files
+ */
+export const queryFilesApiV1BetaFilesQueryPost = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<QueryFilesApiV1BetaFilesQueryPostData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).post<
+    QueryFilesApiV1BetaFilesQueryPostResponse,
+    QueryFilesApiV1BetaFilesQueryPostError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/beta/files/query",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+};
+
+/**
+ * Delete File
+ * Delete a single file from the project.
+ *
+ * Args:
+ * file_id: The ID of the file to delete
+ * project: Validated project from dependency
+ * db: Database session
+ *
+ * Returns:
+ * None (204 No Content on success)
+ */
+export const deleteFileApiV1BetaFilesFileIdDelete = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<DeleteFileApiV1BetaFilesFileIdDeleteData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).delete<
+    DeleteFileApiV1BetaFilesFileIdDeleteResponse,
+    DeleteFileApiV1BetaFilesFileIdDeleteError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/beta/files/{file_id}",
+    ...options,
+  });
+};
+
+/**
+ * List Parse Configurations
+ * List parse configurations for the current project.
+ *
+ * Args:
+ * project: Validated project from dependency
+ * user: Current user
+ * db: Database session
+ * page_size: Number of items per page
+ * page_token: Token for pagination
+ * name: Filter by configuration name
+ * creator: Filter by creator
+ * version: Filter by version
+ *
+ * Returns:
+ * Paginated response with parse configurations
+ */
+export const listParseConfigurationsApiV1BetaParseConfigurationsGet = <
+  ThrowOnError extends boolean = false,
+>(
+  options?: Options<
+    ListParseConfigurationsApiV1BetaParseConfigurationsGetData,
+    ThrowOnError
+  >,
+) => {
+  return (options?.client ?? _heyApiClient).get<
+    ListParseConfigurationsApiV1BetaParseConfigurationsGetResponse,
+    ListParseConfigurationsApiV1BetaParseConfigurationsGetError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/beta/parse-configurations",
+    ...options,
+  });
+};
+
+/**
+ * Create Parse Configuration
+ * Create a new parse configuration.
+ *
+ * Args:
+ * config_create: Parse configuration creation data
+ * project: Validated project from dependency
+ * user: Current user
+ * db: Database session
+ *
+ * Returns:
+ * The created parse configuration
+ */
+export const createParseConfigurationApiV1BetaParseConfigurationsPost = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    CreateParseConfigurationApiV1BetaParseConfigurationsPostData,
+    ThrowOnError
+  >,
+) => {
+  return (options.client ?? _heyApiClient).post<
+    CreateParseConfigurationApiV1BetaParseConfigurationsPostResponse,
+    CreateParseConfigurationApiV1BetaParseConfigurationsPostError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/beta/parse-configurations",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+};
+
+/**
+ * Upsert Parse Configuration
+ * Create or update a parse configuration by name.
+ *
+ * Args:
+ * config_create: Parse configuration creation data
+ * project: Validated project from dependency
+ * user: Current user
+ * db: Database session
+ *
+ * Returns:
+ * The created or updated parse configuration
+ */
+export const upsertParseConfigurationApiV1BetaParseConfigurationsPut = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    UpsertParseConfigurationApiV1BetaParseConfigurationsPutData,
+    ThrowOnError
+  >,
+) => {
+  return (options.client ?? _heyApiClient).put<
+    UpsertParseConfigurationApiV1BetaParseConfigurationsPutResponse,
+    UpsertParseConfigurationApiV1BetaParseConfigurationsPutError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/beta/parse-configurations",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+};
+
+/**
+ * Delete Parse Configuration
+ * Delete a parse configuration.
+ *
+ * Args:
+ * config_id: The ID of the parse configuration to delete
+ * project: Validated project from dependency
+ * user: Current user
+ * db: Database session
+ */
+export const deleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDelete =
+  <ThrowOnError extends boolean = false>(
+    options: Options<
+      DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteData,
+      ThrowOnError
+    >,
+  ) => {
+    return (options.client ?? _heyApiClient).delete<
+      DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteResponse,
+      DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteError,
+      ThrowOnError
+    >({
+      security: [
+        {
+          scheme: "bearer",
+          type: "http",
+        },
+        {
+          scheme: "bearer",
+          type: "http",
+        },
+      ],
+      url: "/api/v1/beta/parse-configurations/{config_id}",
+      ...options,
+    });
+  };
+
+/**
+ * Get Parse Configuration
+ * Get a parse configuration by ID.
+ *
+ * Args:
+ * config_id: The ID of the parse configuration
+ * project: Validated project from dependency
+ * user: Current user
+ * db: Database session
+ *
+ * Returns:
+ * The parse configuration
+ */
+export const getParseConfigurationApiV1BetaParseConfigurationsConfigIdGet = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetData,
+    ThrowOnError
+  >,
+) => {
+  return (options.client ?? _heyApiClient).get<
+    GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetResponse,
+    GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/beta/parse-configurations/{config_id}",
+    ...options,
+  });
+};
+
+/**
+ * Update Parse Configuration
+ * Update a parse configuration.
+ *
+ * Args:
+ * config_id: The ID of the parse configuration to update
+ * config_update: Update data
+ * project: Validated project from dependency
+ * user: Current user
+ * db: Database session
+ *
+ * Returns:
+ * The updated parse configuration
+ */
+export const updateParseConfigurationApiV1BetaParseConfigurationsConfigIdPut = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutData,
+    ThrowOnError
+  >,
+) => {
+  return (options.client ?? _heyApiClient).put<
+    UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutResponse,
+    UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/beta/parse-configurations/{config_id}",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+};
+
+/**
+ * Query Parse Configurations
+ * Query parse configurations with filtering and pagination.
+ *
+ * Args:
+ * query_request: Query request with filters and pagination
+ * project: Validated project from dependency
+ * user: Current user
+ * db: Database session
+ *
+ * Returns:
+ * Paginated response with parse configurations
+ */
+export const queryParseConfigurationsApiV1BetaParseConfigurationsQueryPost = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostData,
+    ThrowOnError
+  >,
+) => {
+  return (options.client ?? _heyApiClient).post<
+    QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostResponse,
+    QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostError,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/beta/parse-configurations/query",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+};
+
+/**
+ * Get Latest Parse Configuration
+ * Get the latest parse configuration for the current project.
+ *
+ * Args:
+ * project: Validated project from dependency
+ * user: Current user
+ * db: Database session
+ * creator: Optional creator filter
+ *
+ * Returns:
+ * The latest parse configuration or None if not found
+ */
+export const getLatestParseConfigurationApiV1BetaParseConfigurationsLatestGet =
+  <ThrowOnError extends boolean = false>(
+    options?: Options<
+      GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetData,
+      ThrowOnError
+    >,
+  ) => {
+    return (options?.client ?? _heyApiClient).get<
+      GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetResponse,
+      GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetError,
+      ThrowOnError
+    >({
+      security: [
+        {
+          scheme: "bearer",
+          type: "http",
+        },
+        {
+          scheme: "bearer",
+          type: "http",
+        },
+      ],
+      url: "/api/v1/beta/parse-configurations/latest",
+      ...options,
+    });
+  };
+
+/**
+ * Upload File V2
+ */
+export const uploadFileV2ApiV2Alpha1ParseUploadPost = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<UploadFileV2ApiV2Alpha1ParseUploadPostData, ThrowOnError>,
+) => {
+  return (options.client ?? _heyApiClient).post<
+    UploadFileV2ApiV2Alpha1ParseUploadPostResponse,
+    UploadFileV2ApiV2Alpha1ParseUploadPostError,
+    ThrowOnError
+  >({
+    ...formDataBodySerializer,
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v2alpha1/parse/upload",
+    ...options,
+    headers: {
+      "Content-Type": null,
+      ...options?.headers,
+    },
+  });
+};
+
+/**
  * Get Job Image Result
  * Get a job by id
  */
@@ -6809,10 +6938,6 @@ export const getJobImageResultApiParsingJobJobIdResultImageNameGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -6930,10 +7055,6 @@ export const getJobApiParsingJobJobIdGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/parsing/job/{job_id}",
     ...options,
@@ -6962,10 +7083,6 @@ export const getJobParametersApiParsingJobJobIdParametersGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/parsing/job/{job_id}/parameters",
     ...options,
@@ -6990,10 +7107,6 @@ export const getParsingJobDetailsApiParsingJobJobIdDetailsGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -7029,10 +7142,6 @@ export const getJobTextResultApiParsingJobJobIdResultTextGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/parsing/job/{job_id}/result/text",
     ...options,
@@ -7057,10 +7166,6 @@ export const getJobRawTextResultRawApiParsingJobJobIdResultRawTextGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -7093,10 +7198,6 @@ export const getJobRawTextResultApiParsingJobJobIdResultPdfGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/parsing/job/{job_id}/result/pdf",
     ...options,
@@ -7121,10 +7222,6 @@ export const getJobRawTextResultRawPdfApiParsingJobJobIdResultRawPdfGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -7160,10 +7257,6 @@ export const getJobStructuredResultApiParsingJobJobIdResultStructuredGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/parsing/job/{job_id}/result/structured",
     ...options,
@@ -7187,10 +7280,6 @@ export const getJobRawStructuredResultApiParsingJobJobIdResultRawStructuredGet =
       ThrowOnError
     >({
       security: [
-        {
-          scheme: "bearer",
-          type: "http",
-        },
         {
           scheme: "bearer",
           type: "http",
@@ -7223,10 +7312,6 @@ export const getJobRawXlsxResultApiParsingJobJobIdResultXlsxGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/parsing/job/{job_id}/result/xlsx",
     ...options,
@@ -7251,10 +7336,6 @@ export const getJobRawXlsxResultRawApiParsingJobJobIdResultRawXlsxGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -7290,10 +7371,6 @@ export const getJobResultApiParsingJobJobIdResultMarkdownGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/parsing/job/{job_id}/result/markdown",
     ...options,
@@ -7318,10 +7395,6 @@ export const getJobRawMdResultApiParsingJobJobIdResultRawMarkdownGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -7357,10 +7430,6 @@ export const getJobJsonResultApiParsingJobJobIdResultJsonGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/parsing/job/{job_id}/result/json",
     ...options,
@@ -7385,10 +7454,6 @@ export const getJobJsonRawResultApiParsingJobJobIdResultRawJsonGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",
@@ -7425,10 +7490,6 @@ export const getParsingHistoryResultApiParsingHistoryGet = <
         scheme: "bearer",
         type: "http",
       },
-      {
-        scheme: "bearer",
-        type: "http",
-      },
     ],
     url: "/api/parsing/history",
     ...options,
@@ -7453,10 +7514,6 @@ export const generatePresignedUrlApiParsingJobJobIdReadFilenameGet = <
     ThrowOnError
   >({
     security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
       {
         scheme: "bearer",
         type: "http",

--- a/ts/llama_cloud_services/src/client/types.gen.ts
+++ b/ts/llama_cloud_services/src/client/types.gen.ts
@@ -65,7 +65,7 @@ export type AdvancedModeTransformConfig = {
  */
 export type AgentData = {
   id?: string | null;
-  agent_slug: string;
+  deployment_name: string;
   collection?: string;
   data: {
     [key: string]: unknown;
@@ -78,7 +78,7 @@ export type AgentData = {
  * API request model for creating agent data
  */
 export type AgentDataCreate = {
-  agent_slug: string;
+  deployment_name: string;
   collection?: string;
   data: {
     [key: string]: unknown;
@@ -113,7 +113,7 @@ export type AgentDeploymentSummary = {
   /**
    * readable ID of the deployed app
    */
-  agent_slug: string;
+  deployment_name: string;
   /**
    * Thumbnail URL of the deployed app
    */
@@ -172,9 +172,9 @@ export type AggregateRequest = {
    */
   order_by?: string | null;
   /**
-   * The agent deployment's agent_slug to aggregate data for
+   * The agent deployment's deployment_name to aggregate data for
    */
-  agent_slug: string;
+  deployment_name: string;
   /**
    * The logical agent data collection to aggregate data for
    */
@@ -7736,9 +7736,9 @@ export type SearchRequest = {
    */
   order_by?: string | null;
   /**
-   * The agent deployment's agent_slug to search within
+   * The agent deployment's deployment_name to search within
    */
-  agent_slug: string;
+  deployment_name: string;
   /**
    * The logical agent data collection to search within
    */

--- a/ts/llama_cloud_services/src/client/types.gen.ts
+++ b/ts/llama_cloud_services/src/client/types.gen.ts
@@ -18,6 +18,7 @@ export type ApiKey = {
   updated_at?: string | null;
   name?: string | null;
   project_id?: string | null;
+  key_type?: ApiKeyType;
   user_id: string;
   redacted_api_key: string;
 };
@@ -31,14 +32,33 @@ export type ApiKeyCreate = {
    * The project ID to associate with the API key.
    */
   project_id?: string | null;
+  key_type?: ApiKeyType;
 };
 
 /**
- * Schema for updating an API key.
+ * Response schema for paginated API key queries.
  */
-export type ApiKeyUpdate = {
-  name?: string | null;
+export type ApiKeyQueryResponse = {
+  /**
+   * The list of items.
+   */
+  items: Array<ApiKey>;
+  /**
+   * A token, which can be sent as page_token to retrieve the next page. If this field is omitted, there are no subsequent pages.
+   */
+  next_page_token?: string | null;
+  /**
+   * The total number of items available. This is only populated when specifically requested. The value may be an estimate and can be used for display purposes only.
+   */
+  total_size?: number | null;
 };
+
+export type ApiKeyType = "user" | "agent";
+
+export const ApiKeyType = {
+  USER: "user",
+  AGENT: "agent",
+} as const;
 
 export type AdvancedModeTransformConfig = {
   mode?: "advanced";
@@ -111,7 +131,7 @@ export type AgentDeploymentSummary = {
    */
   project_id: string;
   /**
-   * readable ID of the deployed app
+   * Identifier of the deployed app
    */
   deployment_name: string;
   /**
@@ -123,10 +143,6 @@ export type AgentDeploymentSummary = {
    */
   base_url: string;
   /**
-   * Display name of the deployed app
-   */
-  display_name: string;
-  /**
    * Timestamp when the app deployment was created
    */
   created_at: string;
@@ -134,6 +150,10 @@ export type AgentDeploymentSummary = {
    * Timestamp when the app deployment was last updated
    */
   updated_at: string;
+  /**
+   * API key ID
+   */
+  api_key_id?: string | null;
 };
 
 /**
@@ -172,7 +192,7 @@ export type AggregateRequest = {
    */
   order_by?: string | null;
   /**
-   * The agent deployment's deployment_name to aggregate data for
+   * The agent deployment's name to aggregate data for
    */
   deployment_name: string;
   /**
@@ -202,14 +222,6 @@ export type AggregateRequest = {
  */
 export type AppChatInputParams = {
   messages?: Array<InputMessage>;
-};
-
-export type AudioBlock = {
-  block_type?: "audio";
-  audio?: (Blob | File) | null;
-  path?: string | null;
-  url?: string | null;
-  format?: string | null;
 };
 
 export type AutoTransformConfig = {
@@ -591,35 +603,6 @@ export type BillingPeriod = {
   end_date: string;
 };
 
-export type BodyClassifyDocumentsApiV1ClassifierClassifyPost = {
-  /**
-   * JSON string containing classifier rules
-   */
-  rules_json: string;
-  files?: Array<Blob | File> | null;
-  /**
-   * Comma-separated list of existing file IDs
-   */
-  file_ids?: string | null;
-  /**
-   * Minimum confidence threshold for acceptable matches (0.1-0.99, default: 0.6)
-   */
-  matching_threshold?: number | null;
-  /**
-   * Enable metadata-based features (document filtering + content classification, default: true)
-   */
-  enable_metadata_heuristic?: boolean | null;
-};
-
-export type BodyCreateReportApiV1ReportsPost = {
-  name: string;
-  template_text?: string;
-  template_instructions?: string | null;
-  existing_retriever_id?: string | null;
-  files: Array<Blob | File>;
-  template_file?: (Blob | File) | null;
-};
-
 export type BodyImportPipelineMetadataApiV1PipelinesPipelineIdMetadataPut = {
   upload_file: Blob | File;
 };
@@ -661,6 +644,7 @@ export type BodyScreenshotApiParsingScreenshotPost = {
   output_s3_region?: string;
   target_pages?: string;
   webhook_url?: string;
+  webhook_configurations?: string;
   job_timeout_in_seconds?: number;
   job_timeout_extra_time_per_page_in_seconds?: number;
 };
@@ -678,6 +662,7 @@ export type BodyScreenshotApiV1ParsingScreenshotPost = {
   output_s3_region?: string;
   target_pages?: string;
   webhook_url?: string;
+  webhook_configurations?: string;
   job_timeout_in_seconds?: number;
   job_timeout_extra_time_per_page_in_seconds?: number;
 };
@@ -710,6 +695,12 @@ export type BodyUploadFileApiParsingUploadPost = {
   guess_xlsx_sheet_name?: boolean;
   high_res_ocr?: boolean;
   html_make_all_elements_visible?: boolean;
+  layout_aware?: boolean;
+  specialized_chart_parsing_agentic?: boolean;
+  specialized_chart_parsing_plus?: boolean;
+  specialized_chart_parsing_efficient?: boolean;
+  specialized_image_parsing?: boolean;
+  precise_bounding_box?: boolean;
   html_remove_fixed_elements?: boolean;
   html_remove_navigation_elements?: boolean;
   http_proxy?: string;
@@ -729,8 +720,11 @@ export type BodyUploadFileApiParsingUploadPost = {
   page_separator?: string;
   page_suffix?: string;
   preserve_layout_alignment_across_pages?: boolean;
+  preserve_very_small_text?: boolean;
   skip_diagonal_text?: boolean;
   spreadsheet_extract_sub_tables?: boolean;
+  spreadsheet_force_formula_computation?: boolean;
+  inline_images_in_markdown?: boolean;
   structured_output?: boolean;
   structured_output_json_schema?: string;
   structured_output_json_schema_name?: string;
@@ -740,6 +734,7 @@ export type BodyUploadFileApiParsingUploadPost = {
   vendor_multimodal_model_name?: string;
   model?: string;
   webhook_url?: string;
+  webhook_configurations?: string;
   preset?: string;
   parse_mode?: ParsingMode | null;
   page_error_tolerance?: number;
@@ -811,6 +806,12 @@ export type BodyUploadFileApiV1ParsingUploadPost = {
   guess_xlsx_sheet_name?: boolean;
   high_res_ocr?: boolean;
   html_make_all_elements_visible?: boolean;
+  layout_aware?: boolean;
+  specialized_chart_parsing_agentic?: boolean;
+  specialized_chart_parsing_plus?: boolean;
+  specialized_chart_parsing_efficient?: boolean;
+  specialized_image_parsing?: boolean;
+  precise_bounding_box?: boolean;
   html_remove_fixed_elements?: boolean;
   html_remove_navigation_elements?: boolean;
   http_proxy?: string;
@@ -830,8 +831,11 @@ export type BodyUploadFileApiV1ParsingUploadPost = {
   page_separator?: string;
   page_suffix?: string;
   preserve_layout_alignment_across_pages?: boolean;
+  preserve_very_small_text?: boolean;
   skip_diagonal_text?: boolean;
   spreadsheet_extract_sub_tables?: boolean;
+  spreadsheet_force_formula_computation?: boolean;
+  inline_images_in_markdown?: boolean;
   structured_output?: boolean;
   structured_output_json_schema?: string;
   structured_output_json_schema_name?: string;
@@ -841,6 +845,7 @@ export type BodyUploadFileApiV1ParsingUploadPost = {
   vendor_multimodal_model_name?: string;
   model?: string;
   webhook_url?: string;
+  webhook_configurations?: string;
   preset?: string;
   parse_mode?: ParsingMode | null;
   page_error_tolerance?: number;
@@ -878,6 +883,11 @@ export type BodyUploadFileApiV1ParsingUploadPost = {
   page_header_suffix?: string;
   page_footer_prefix?: string;
   page_footer_suffix?: string;
+};
+
+export type BodyUploadFileV2ApiV2Alpha1ParseUploadPost = {
+  configuration: string;
+  file?: (Blob | File) | null;
 };
 
 export type BoxAuthMechanism = "developer_token" | "ccg";
@@ -1010,6 +1020,33 @@ export type ChatInputParams = {
   class_name?: string;
 };
 
+export type ChatMessage = {
+  id: string;
+  /**
+   * The index of the message in the chat.
+   */
+  index: number;
+  /**
+   * Retrieval annotations for the message.
+   */
+  annotations?: Array<MessageAnnotation>;
+  /**
+   * The role of the message.
+   */
+  role: MessageRole;
+  /**
+   * Text content of the generation
+   */
+  content?: string | null;
+  /**
+   * Additional arguments passed to the model
+   */
+  additional_kwargs?: {
+    [key: string]: string;
+  };
+  class_name?: string;
+};
+
 export type ChunkMode = "PAGE" | "DOCUMENT" | "SECTION" | "GROUPED_PAGES";
 
 export const ChunkMode = {
@@ -1021,38 +1058,103 @@ export const ChunkMode = {
 
 /**
  * Result of classifying a single file.
- *
- * Contains the classification outcome with confidence score and matched rule info.
  */
 export type ClassificationResult = {
   /**
-   * The ID of the classified file
+   * Step-by-step explanation of why this classification was chosen and the confidence score assigned
    */
-  file_id: string;
-  /**
-   * The assigned document type ('unknown' if no rules matched)
-   */
-  type: string;
+  reasoning: string;
   /**
    * Confidence score of the classification (0.0-1.0)
    */
   confidence: number;
   /**
-   * Description of the rule that matched, or method used (e.g., 'auto: filename contains invoice')
+   * The document type that best matches, or null if no match.
    */
-  matched_rule: string | null;
+  type: string | null;
+};
+
+/**
+ * A rule for classifying documents - v0 simplified version.
+ *
+ * This represents a single classification rule that will be applied to documents.
+ * All rules are content-based and use natural language descriptions.
+ */
+export type ClassifierRule = {
+  /**
+   * The document type to assign when this rule matches (e.g., 'invoice', 'receipt', 'contract')
+   */
+  type: string;
+  /**
+   * Natural language description of what to classify. Be specific about the content characteristics that identify this document type.
+   */
+  description: string;
+};
+
+/**
+ * A classify job.
+ */
+export type ClassifyJob = {
+  /**
+   * Unique identifier
+   */
+  id: string;
+  /**
+   * Creation datetime
+   */
+  created_at?: string | null;
+  /**
+   * Update datetime
+   */
+  updated_at?: string | null;
+  /**
+   * The rules to classify the files
+   */
+  rules: Array<ClassifierRule>;
+  /**
+   * The ID of the user
+   */
+  user_id: string;
+  /**
+   * The ID of the project
+   */
+  project_id: string;
+  /**
+   * The status of the classify job
+   */
+  status: StatusEnum;
+  /**
+   * The configuration for the parsing job
+   */
+  parsing_configuration?: ClassifyParsingConfiguration;
+};
+
+/**
+ * A classify job.
+ */
+export type ClassifyJobCreate = {
+  /**
+   * The rules to classify the files
+   */
+  rules: Array<ClassifierRule>;
+  /**
+   * The IDs of the files to classify
+   */
+  file_ids: Array<string>;
+  /**
+   * The configuration for the parsing job
+   */
+  parsing_configuration?: ClassifyParsingConfiguration;
 };
 
 /**
  * Response model for the classify endpoint following AIP-132 pagination standard.
- *
- * Contains classification results with pagination support and summary statistics.
  */
-export type ClassifyResponse = {
+export type ClassifyJobResults = {
   /**
    * The list of items.
    */
-  items: Array<ClassificationResult>;
+  items: Array<FileClassification>;
   /**
    * A token, which can be sent as page_token to retrieve the next page. If this field is omitted, there are no subsequent pages.
    */
@@ -1061,10 +1163,96 @@ export type ClassifyResponse = {
    * The total number of items available. This is only populated when specifically requested. The value may be an estimate and can be used for display purposes only.
    */
   total_size?: number | null;
+};
+
+/**
+ * Parsing configuration for a classify job.
+ */
+export type ClassifyParsingConfiguration = {
   /**
-   * Number of files that couldn't be classified
+   * The language to parse the files in
    */
-  unknown_count: number;
+  lang?: ParserLanguages;
+  /**
+   * The maximum number of pages to parse
+   */
+  max_pages?: number | null;
+  /**
+   * The pages to target for parsing (0-indexed, so first page is at 0)
+   */
+  target_pages?: Array<number> | null;
+};
+
+/**
+ * Cloud AstraDB Vector Store.
+ *
+ * This class is used to store the configuration for an AstraDB vector store, so that it can be
+ * created and used in LlamaCloud.
+ *
+ * Args:
+ * token (str): The Astra DB Application Token to use.
+ * api_endpoint (str): The Astra DB JSON API endpoint for your database.
+ * collection_name (str): Collection name to use. If not existing, it will be created.
+ * embedding_dimension (int): Length of the embedding vectors in use.
+ * keyspace (optional[str]): The keyspace to use. If not provided, 'default_keyspace'
+ */
+export type CloudAstraDbVectorStoreReadable = {
+  supports_nested_metadata_filters?: true;
+  /**
+   * The Astra DB JSON API endpoint for your database
+   */
+  api_endpoint: string;
+  /**
+   * Collection name to use. If not existing, it will be created
+   */
+  collection_name: string;
+  /**
+   * Length of the embedding vectors in use
+   */
+  embedding_dimension: number;
+  /**
+   * The keyspace to use. If not provided, 'default_keyspace'
+   */
+  keyspace?: string | null;
+  class_name?: string;
+};
+
+/**
+ * Cloud AstraDB Vector Store.
+ *
+ * This class is used to store the configuration for an AstraDB vector store, so that it can be
+ * created and used in LlamaCloud.
+ *
+ * Args:
+ * token (str): The Astra DB Application Token to use.
+ * api_endpoint (str): The Astra DB JSON API endpoint for your database.
+ * collection_name (str): Collection name to use. If not existing, it will be created.
+ * embedding_dimension (int): Length of the embedding vectors in use.
+ * keyspace (optional[str]): The keyspace to use. If not provided, 'default_keyspace'
+ */
+export type CloudAstraDbVectorStoreWritable = {
+  supports_nested_metadata_filters?: true;
+  /**
+   * The Astra DB Application Token to use
+   */
+  token: string;
+  /**
+   * The Astra DB JSON API endpoint for your database
+   */
+  api_endpoint: string;
+  /**
+   * Collection name to use. If not existing, it will be created
+   */
+  collection_name: string;
+  /**
+   * Length of the embedding vectors in use
+   */
+  embedding_dimension: number;
+  /**
+   * The keyspace to use. If not provided, 'default_keyspace'
+   */
+  keyspace?: string | null;
+  class_name?: string;
 };
 
 export type CloudAzStorageBlobDataSourceReadable = {
@@ -1294,6 +1482,18 @@ export type CloudConfluenceDataSourceReadable = {
    * Whether to keep the markdown format.
    */
   keep_markdown_format?: boolean;
+  /**
+   * Configuration for handling failures during processing. Key-value object controlling failure handling behaviors.
+   *
+   * Example:
+   * {
+   * "skip_list_failures": true
+   * }
+   *
+   * Currently supports:
+   * - skip_list_failures: Skip failed batches/lists and continue processing
+   */
+  failure_handling?: FailureHandlingConfig;
   class_name?: string;
 };
 
@@ -1339,6 +1539,18 @@ export type CloudConfluenceDataSourceWritable = {
    * Whether to keep the markdown format.
    */
   keep_markdown_format?: boolean;
+  /**
+   * Configuration for handling failures during processing. Key-value object controlling failure handling behaviors.
+   *
+   * Example:
+   * {
+   * "skip_list_failures": true
+   * }
+   *
+   * Currently supports:
+   * - skip_list_failures: Skip failed batches/lists and continue processing
+   */
+  failure_handling?: FailureHandlingConfig;
   class_name?: string;
 };
 
@@ -1437,6 +1649,110 @@ export type CloudJiraDataSourceWritable = {
    * JQL (Jira Query Language) query to search.
    */
   query: string;
+  class_name?: string;
+};
+
+/**
+ * Cloud Jira Data Source integrating JiraReaderV2.
+ */
+export type CloudJiraDataSourceV2Readable = {
+  supports_access_control?: boolean;
+  /**
+   * The email address to use for authentication.
+   */
+  email?: string | null;
+  /**
+   * The API Access Token used for Basic, PAT and OAuth2 authentication.
+   */
+  api_token?: string | null;
+  /**
+   * The server url for Jira Cloud.
+   */
+  server_url: string;
+  /**
+   * The cloud ID, used in case of OAuth2.
+   */
+  cloud_id?: string | null;
+  /**
+   * Type of Authentication for connecting to Jira APIs.
+   */
+  authentication_mechanism: string;
+  /**
+   * Jira REST API version to use (2 or 3). 3 supports Atlassian Document Format (ADF).
+   */
+  api_version?: "2" | "3";
+  /**
+   * JQL (Jira Query Language) query to search.
+   */
+  query: string;
+  /**
+   * List of fields to retrieve from Jira. If None, retrieves all fields.
+   */
+  fields?: Array<string> | null;
+  /**
+   * Fields to expand in the response.
+   */
+  expand?: string | null;
+  /**
+   * Rate limit for Jira API requests per minute.
+   */
+  requests_per_minute?: number | null;
+  /**
+   * Whether to fetch project role permissions and issue-level security
+   */
+  get_permissions?: boolean;
+  class_name?: string;
+};
+
+/**
+ * Cloud Jira Data Source integrating JiraReaderV2.
+ */
+export type CloudJiraDataSourceV2Writable = {
+  supports_access_control?: boolean;
+  /**
+   * The email address to use for authentication.
+   */
+  email?: string | null;
+  /**
+   * The API Access Token used for Basic, PAT and OAuth2 authentication.
+   */
+  api_token?: string | null;
+  /**
+   * The server url for Jira Cloud.
+   */
+  server_url: string;
+  /**
+   * The cloud ID, used in case of OAuth2.
+   */
+  cloud_id?: string | null;
+  /**
+   * Type of Authentication for connecting to Jira APIs.
+   */
+  authentication_mechanism: string;
+  /**
+   * Jira REST API version to use (2 or 3). 3 supports Atlassian Document Format (ADF).
+   */
+  api_version?: "2" | "3";
+  /**
+   * JQL (Jira Query Language) query to search.
+   */
+  query: string;
+  /**
+   * List of fields to retrieve from Jira. If None, retrieves all fields.
+   */
+  fields?: Array<string> | null;
+  /**
+   * Fields to expand in the response.
+   */
+  expand?: string | null;
+  /**
+   * Rate limit for Jira API requests per minute.
+   */
+  requests_per_minute?: number | null;
+  /**
+   * Whether to fetch project role permissions and issue-level security
+   */
+  get_permissions?: boolean;
   class_name?: string;
 };
 
@@ -2084,7 +2400,8 @@ export type ConfigurableDataSinkNames =
   | "QDRANT"
   | "AZUREAI_SEARCH"
   | "MONGODB_ATLAS"
-  | "MILVUS";
+  | "MILVUS"
+  | "ASTRA_DB";
 
 export const ConfigurableDataSinkNames = {
   PINECONE: "PINECONE",
@@ -2093,6 +2410,7 @@ export const ConfigurableDataSinkNames = {
   AZUREAI_SEARCH: "AZUREAI_SEARCH",
   MONGODB_ATLAS: "MONGODB_ATLAS",
   MILVUS: "MILVUS",
+  ASTRA_DB: "ASTRA_DB",
 } as const;
 
 export type ConfigurableDataSourceNames =
@@ -2105,6 +2423,7 @@ export type ConfigurableDataSourceNames =
   | "NOTION_PAGE"
   | "CONFLUENCE"
   | "JIRA"
+  | "JIRA_V2"
   | "BOX";
 
 export const ConfigurableDataSourceNames = {
@@ -2117,6 +2436,7 @@ export const ConfigurableDataSourceNames = {
   NOTION_PAGE: "NOTION_PAGE",
   CONFLUENCE: "CONFLUENCE",
   JIRA: "JIRA",
+  JIRA_V2: "JIRA_V2",
   BOX: "BOX",
 } as const;
 
@@ -2128,6 +2448,53 @@ export type CreateIntentAndCustomerSessionResponse = {
 export type CreditType = {
   id: string;
   name: string;
+};
+
+/**
+ * Custom claims that dictate various limits or allowed behaviors.
+ * Currently these claims reside at a per user level. Claims may expand to a per organization level or project in the future.
+ */
+export type CustomClaims = {
+  /**
+   * Whether the user is allowed to create organizations.
+   */
+  allowed_org_creation?: boolean;
+  /**
+   * The maximum number of jobs the user can have in execution per job type.
+   */
+  max_jobs_in_execution_per_job_type?: number;
+  /**
+   * The maximum number of document ingestion jobs the user can have in execution.
+   */
+  max_document_ingestion_jobs_in_execution?: number;
+  /**
+   * The maximum number of metadata update jobs the user can have in execution.
+   */
+  max_metadata_update_jobs_in_execution?: number;
+  /**
+   * Whether the user is a test user for extraction. This will include additional debug metadata and access to test endpoints.
+   */
+  extraction_test_user?: boolean;
+  /**
+   * Whether the user is allowed to access llama-report generation.
+   */
+  allowed_report?: boolean;
+  /**
+   * Whether the user is allowed to access the app.
+   */
+  allowed_app?: boolean;
+  /**
+   * Whether the user is allowed to access the classifier feature.
+   */
+  allowed_classify?: boolean;
+  /**
+   * Whether the user is allowed to access API data sources.
+   */
+  api_datasource_access?: boolean;
+  /**
+   * Whether the user is allowed to delete organizations.
+   */
+  allow_org_deletion?: boolean;
 };
 
 export type CustomerPortalSessionCreatePayload = {
@@ -2167,7 +2534,8 @@ export type DataSinkReadable = {
     | CloudQdrantVectorStoreReadable
     | CloudAzureAiSearchVectorStoreReadable
     | CloudMongoDbAtlasVectorSearchReadable
-    | CloudMilvusVectorStoreReadable;
+    | CloudMilvusVectorStoreReadable
+    | CloudAstraDbVectorStoreReadable;
   project_id: string;
 };
 
@@ -2204,7 +2572,8 @@ export type DataSinkWritable = {
     | CloudQdrantVectorStoreWritable
     | CloudAzureAiSearchVectorStoreWritable
     | CloudMongoDbAtlasVectorSearchWritable
-    | CloudMilvusVectorStoreWritable;
+    | CloudMilvusVectorStoreWritable
+    | CloudAstraDbVectorStoreWritable;
   project_id: string;
 };
 
@@ -2229,7 +2598,8 @@ export type DataSinkCreateReadable = {
     | CloudQdrantVectorStoreReadable
     | CloudAzureAiSearchVectorStoreReadable
     | CloudMongoDbAtlasVectorSearchReadable
-    | CloudMilvusVectorStoreReadable;
+    | CloudMilvusVectorStoreReadable
+    | CloudAstraDbVectorStoreReadable;
 };
 
 /**
@@ -2253,7 +2623,8 @@ export type DataSinkCreateWritable = {
     | CloudQdrantVectorStoreWritable
     | CloudAzureAiSearchVectorStoreWritable
     | CloudMongoDbAtlasVectorSearchWritable
-    | CloudMilvusVectorStoreWritable;
+    | CloudMilvusVectorStoreWritable
+    | CloudAstraDbVectorStoreWritable;
 };
 
 /**
@@ -2278,6 +2649,7 @@ export type DataSinkUpdateReadable = {
     | CloudAzureAiSearchVectorStoreReadable
     | CloudMongoDbAtlasVectorSearchReadable
     | CloudMilvusVectorStoreReadable
+    | CloudAstraDbVectorStoreReadable
     | null;
 };
 
@@ -2303,6 +2675,7 @@ export type DataSinkUpdateWritable = {
     | CloudAzureAiSearchVectorStoreWritable
     | CloudMongoDbAtlasVectorSearchWritable
     | CloudMilvusVectorStoreWritable
+    | CloudAstraDbVectorStoreWritable
     | null;
 };
 
@@ -2357,6 +2730,7 @@ export type DataSourceReadable = {
     | CloudNotionPageDataSourceReadable
     | CloudConfluenceDataSourceReadable
     | CloudJiraDataSourceReadable
+    | CloudJiraDataSourceV2Readable
     | CloudBoxDataSourceReadable;
   /**
    * Version metadata for the data source
@@ -2416,6 +2790,7 @@ export type DataSourceWritable = {
     | CloudNotionPageDataSourceWritable
     | CloudConfluenceDataSourceWritable
     | CloudJiraDataSourceWritable
+    | CloudJiraDataSourceV2Writable
     | CloudBoxDataSourceWritable;
   /**
    * Version metadata for the data source
@@ -2463,6 +2838,7 @@ export type DataSourceCreateReadable = {
     | CloudNotionPageDataSourceReadable
     | CloudConfluenceDataSourceReadable
     | CloudJiraDataSourceReadable
+    | CloudJiraDataSourceV2Readable
     | CloudBoxDataSourceReadable;
 };
 
@@ -2505,6 +2881,7 @@ export type DataSourceCreateWritable = {
     | CloudNotionPageDataSourceWritable
     | CloudConfluenceDataSourceWritable
     | CloudJiraDataSourceWritable
+    | CloudJiraDataSourceV2Writable
     | CloudBoxDataSourceWritable;
 };
 
@@ -2512,7 +2889,7 @@ export type DataSourceReaderVersionMetadata = {
   /**
    * The version of the reader to use for this data source.
    */
-  reader_version?: string | null;
+  reader_version?: ("1.0" | "2.0" | "2.1") | null;
 };
 
 /**
@@ -2554,6 +2931,7 @@ export type DataSourceUpdateReadable = {
     | CloudNotionPageDataSourceReadable
     | CloudConfluenceDataSourceReadable
     | CloudJiraDataSourceReadable
+    | CloudJiraDataSourceV2Readable
     | CloudBoxDataSourceReadable
     | null;
 };
@@ -2597,6 +2975,7 @@ export type DataSourceUpdateWritable = {
     | CloudNotionPageDataSourceWritable
     | CloudConfluenceDataSourceWritable
     | CloudJiraDataSourceWritable
+    | CloudJiraDataSourceV2Writable
     | CloudBoxDataSourceWritable
     | null;
 };
@@ -2682,15 +3061,6 @@ export type DirectRetrievalParams = {
   pipelines?: Array<RetrieverPipeline>;
 };
 
-export type DocumentBlock = {
-  block_type?: "document";
-  data?: (Blob | File) | null;
-  path?: string | null;
-  url?: string | null;
-  title?: string | null;
-  document_mimetype?: string | null;
-};
-
 export type DocumentChunkMode = "PAGE" | "SECTION";
 
 export const DocumentChunkMode = {
@@ -2739,23 +3109,6 @@ export type DocumentIngestionJobParams = {
    * The number of pages in the file. Only used if used llama-parse
    */
   page_count?: number | null;
-};
-
-/**
- * A suggestion for an edit to a report.
- */
-export type EditSuggestion = {
-  justification: string;
-  blocks: Array<ReportBlock | ReportPlanBlock>;
-  removed_indices?: Array<number>;
-};
-
-/**
- * A request to suggest edits for a report.
- */
-export type EditSuggestionCreate = {
-  user_query: string;
-  chat_history: Array<LlamaIndexCoreBaseLlmsTypesChatMessage>;
 };
 
 export type ElementSegmentationConfig = {
@@ -2927,6 +3280,10 @@ export type ExtractAgent = {
    */
   config: ExtractConfig;
   /**
+   * Custom configuration type for the extraction agent. Currently supports 'default'.
+   */
+  custom_configuration?: "default" | null;
+  /**
    * The creation time of the extraction agent.
    */
   created_at?: string | null;
@@ -3007,11 +3364,19 @@ export type ExtractConfig = {
    */
   extraction_target?: ExtractTarget;
   /**
-   * The extraction mode specified.
+   * The extraction mode specified (FAST, BALANCED, MULTIMODAL, PREMIUM).
    */
   extraction_mode?: ExtractMode;
   /**
-   * Whether to use fast mode for multimodal extraction.
+   * The parse model to use for document parsing. If not provided, uses the default for the extraction mode.
+   */
+  parse_model?: PublicModelName | null;
+  /**
+   * The extract model to use for data extraction. If not provided, uses the default for the extraction mode.
+   */
+  extract_model?: ExtractModels | null;
+  /**
+   * DEPRECATED: Whether to use fast mode for multimodal extraction.
    */
   multimodal_fast_mode?: boolean;
   /**
@@ -3027,13 +3392,25 @@ export type ExtractConfig = {
    */
   cite_sources?: boolean;
   /**
+   * Whether to fetch confidence scores for the extraction.
+   */
+  confidence_scores?: boolean;
+  /**
    * The mode to use for chunking the document.
    */
   chunk_mode?: DocumentChunkMode;
   /**
+   * Whether to use high resolution mode for the extraction.
+   */
+  high_resolution_mode?: boolean;
+  /**
    * Whether to invalidate the cache for the extraction.
    */
   invalidate_cache?: boolean;
+  /**
+   * Comma-separated list of page numbers or ranges to extract from (1-based, e.g., '1,3,5-7,9' or '1-3,8-10').
+   */
+  page_range?: string | null;
 };
 
 export type ExtractJob = {
@@ -3063,6 +3440,10 @@ export type ExtractJob = {
  * Schema for creating an extraction job.
  */
 export type ExtractJobCreate = {
+  /**
+   * The priority for the request. This field may be ignored or overwritten depending on the organization tier.
+   */
+  priority?: ("low" | "medium" | "high" | "critical") | null;
   /**
    * The outbound webhook configurations
    */
@@ -3145,28 +3526,28 @@ export const ExtractMode = {
 } as const;
 
 export type ExtractModels =
-  | "gpt-4.1"
-  | "gpt-4.1-mini"
-  | "gpt-4.1-nano"
+  | "openai-gpt-4-1"
+  | "openai-gpt-4-1-mini"
+  | "openai-gpt-4-1-nano"
+  | "openai-gpt-5"
+  | "openai-gpt-5-mini"
   | "gemini-2.0-flash"
-  | "o3-mini"
   | "gemini-2.5-flash"
   | "gemini-2.5-pro"
-  | "gemini-2.5-flash-lite-preview-06-17"
-  | "gpt-4o"
-  | "gpt-4o-mini";
+  | "openai-gpt-4o"
+  | "openai-gpt-4o-mini";
 
 export const ExtractModels = {
-  GPT_4_1: "gpt-4.1",
-  GPT_4_1_MINI: "gpt-4.1-mini",
-  GPT_4_1_NANO: "gpt-4.1-nano",
+  OPENAI_GPT_4_1: "openai-gpt-4-1",
+  OPENAI_GPT_4_1_MINI: "openai-gpt-4-1-mini",
+  OPENAI_GPT_4_1_NANO: "openai-gpt-4-1-nano",
+  OPENAI_GPT_5: "openai-gpt-5",
+  OPENAI_GPT_5_MINI: "openai-gpt-5-mini",
   GEMINI_2_0_FLASH: "gemini-2.0-flash",
-  O3_MINI: "o3-mini",
   GEMINI_2_5_FLASH: "gemini-2.5-flash",
   GEMINI_2_5_PRO: "gemini-2.5-pro",
-  GEMINI_2_5_FLASH_LITE_PREVIEW_06_17: "gemini-2.5-flash-lite-preview-06-17",
-  GPT_4O: "gpt-4o",
-  GPT_4O_MINI: "gpt-4o-mini",
+  OPENAI_GPT_4O: "openai-gpt-4o",
+  OPENAI_GPT_4O_MINI: "openai-gpt-4o-mini",
 } as const;
 
 /**
@@ -3408,6 +3789,49 @@ export const ExtractState = {
   ERROR: "ERROR",
 } as const;
 
+/**
+ * Schema for stateless extraction requests.
+ */
+export type ExtractStatelessRequest = {
+  /**
+   * The outbound webhook configurations
+   */
+  webhook_configurations?: Array<WebhookConfiguration> | null;
+  /**
+   * The schema of the data to extract
+   */
+  data_schema:
+    | {
+        [key: string]:
+          | {
+              [key: string]: unknown;
+            }
+          | Array<unknown>
+          | string
+          | number
+          | number
+          | boolean
+          | null;
+      }
+    | string;
+  /**
+   * The configuration parameters for the extraction
+   */
+  config: ExtractConfig;
+  /**
+   * The ID of the file to extract from
+   */
+  file_id?: string | null;
+  /**
+   * The text content to extract from
+   */
+  text?: string | null;
+  /**
+   * The file data with base64 content and MIME type
+   */
+  file?: FileData | null;
+};
+
 export type ExtractTarget = "PER_DOC" | "PER_PAGE";
 
 export const ExtractTarget = {
@@ -3430,6 +3854,16 @@ export const FailPageMode = {
 } as const;
 
 /**
+ * Configuration for handling different types of failures during data source processing.
+ */
+export type FailureHandlingConfig = {
+  /**
+   * Whether to skip failed batches/lists and continue processing
+   */
+  skip_list_failures?: boolean;
+};
+
+/**
  * Schema for a file.
  */
 export type File = {
@@ -3449,7 +3883,7 @@ export type File = {
   /**
    * The ID of the file in the external system
    */
-  external_file_id: string;
+  external_file_id?: string | null;
   /**
    * Size of the file in bytes
    */
@@ -3500,6 +3934,36 @@ export type File = {
    * The ID of the data source that the file belongs to
    */
   data_source_id?: string | null;
+};
+
+/**
+ * A file classification.
+ */
+export type FileClassification = {
+  /**
+   * Unique identifier
+   */
+  id: string;
+  /**
+   * Creation datetime
+   */
+  created_at?: string | null;
+  /**
+   * Update datetime
+   */
+  updated_at?: string | null;
+  /**
+   * The ID of the classify job
+   */
+  classify_job_id: string;
+  /**
+   * The ID of the classified file
+   */
+  file_id: string;
+  /**
+   * The classification result
+   */
+  result?: ClassificationResult | null;
 };
 
 export type FileCountByStatusResponse = {
@@ -3625,6 +4089,50 @@ export type FileCreateFromUrl = {
 };
 
 /**
+ * Schema for file data with base64 content and MIME type.
+ */
+export type FileData = {
+  /**
+   * The file content as base64-encoded string
+   */
+  data: string;
+  /**
+   * The MIME type of the file (e.g., 'application/pdf', 'text/plain')
+   */
+  mime_type: string;
+};
+
+/**
+ * Filter parameters for file queries.
+ */
+export type FileFilter = {
+  /**
+   * Filter by project ID
+   */
+  project_id?: string | null;
+  /**
+   * Filter by specific file IDs
+   */
+  file_ids?: Array<string> | null;
+  /**
+   * Filter by file name
+   */
+  file_name?: string | null;
+  /**
+   * Filter by data source ID
+   */
+  data_source_id?: string | null;
+  /**
+   * Filter by external file ID
+   */
+  external_file_id?: string | null;
+  /**
+   * Filter only manually uploaded files (data_source_id is null)
+   */
+  only_manually_uploaded?: boolean | null;
+};
+
+/**
  * Schema for a presigned URL with a file ID.
  */
 export type FileIdPresignedUrl = {
@@ -3673,6 +4181,46 @@ export type FileParsePublic = {
    * The path to the data file.
    */
   data_path: string;
+};
+
+/**
+ * Request schema for querying files with pagination and filtering.
+ */
+export type FileQueryRequest = {
+  /**
+   * The maximum number of items to return. The service may return fewer than this value. If unspecified, a default page size will be used. The maximum value is typically 1000; values above this will be coerced to the maximum.
+   */
+  page_size?: number | null;
+  /**
+   * A page token, received from a previous list call. Provide this to retrieve the subsequent page.
+   */
+  page_token?: string | null;
+  /**
+   * A filter object or expression that filters resources listed in the response.
+   */
+  filter?: FileFilter | null;
+  /**
+   * A comma-separated list of fields to order by, sorted in ascending order. Use 'field_name desc' to specify descending order.
+   */
+  order_by?: string | null;
+};
+
+/**
+ * Response schema for paginated file queries.
+ */
+export type FileQueryResponse = {
+  /**
+   * The list of items.
+   */
+  items: Array<File>;
+  /**
+   * A token, which can be sent as page_token to retrieve the next page. If this field is omitted, there are no subsequent pages.
+   */
+  next_page_token?: string | null;
+  /**
+   * The total number of items available. This is only populated when specifically requested. The value may be an estimate and can be used for display purposes only.
+   */
+  total_size?: number | null;
 };
 
 /**
@@ -3861,15 +4409,6 @@ export type HuggingFaceInferenceApiEmbeddingConfig = {
   component?: HuggingFaceInferenceApiEmbedding;
 };
 
-export type ImageBlock = {
-  block_type?: "image";
-  image?: (Blob | File) | null;
-  path?: string | null;
-  url?: string | null;
-  image_mimetype?: string | null;
-  detail?: string | null;
-};
-
 export type IngestionErrorResponse = {
   /**
    * ID of the job that failed.
@@ -3939,7 +4478,6 @@ export type JobNames =
   | "load_files_job"
   | "playground_job"
   | "pipeline_managed_ingestion_job"
-  | "data_source_managed_ingestion_job"
   | "data_source_update_dispatcher_job"
   | "pipeline_file_update_dispatcher_job"
   | "pipeline_file_updater_job"
@@ -3961,7 +4499,6 @@ export const JobNames = {
   LOAD_FILES_JOB: "load_files_job",
   PLAYGROUND_JOB: "playground_job",
   PIPELINE_MANAGED_INGESTION_JOB: "pipeline_managed_ingestion_job",
-  DATA_SOURCE_MANAGED_INGESTION_JOB: "data_source_managed_ingestion_job",
   DATA_SOURCE_UPDATE_DISPATCHER_JOB: "data_source_update_dispatcher_job",
   PIPELINE_FILE_UPDATE_DISPATCHER_JOB: "pipeline_file_update_dispatcher_job",
   PIPELINE_FILE_UPDATER_JOB: "pipeline_file_updater_job",
@@ -4225,6 +4762,10 @@ export type LegacyParseJobConfig = {
    */
   preserveLayoutAlignmentAcrossPages?: boolean;
   /**
+   * Whether to preserve very small text lines.
+   */
+  preserveVerySmallText?: boolean;
+  /**
    * Whether to invalidate the cache.
    */
   invalidateCache: boolean;
@@ -4260,6 +4801,10 @@ export type LegacyParseJobConfig = {
    * Whether to extract subTables from spreadsheet.
    */
   spreadSheetExtractSubTables?: boolean | null;
+  /**
+   * Whether to force re-computation of spreadsheet cells containing formulas.
+   */
+  spreadSheetForceFormulaComputation?: boolean | null;
   /**
    * Whether to perform layout extraction.
    */
@@ -4590,19 +5135,27 @@ export type LlamaExtractSettings = {
    */
   use_multimodal_parsing?: boolean;
   /**
-   * Whether to use extraction over pixels for multimodal mode.
+   * DEPRECATED: Whether to use extraction over pixels for multimodal mode.
    */
   use_pixel_extraction?: boolean;
   /**
    * LlamaParse related settings.
    */
   llama_parse_params?: LlamaParseParameters;
+  /**
+   * The resolution to use for multimodal parsing.
+   */
+  multimodal_parse_resolution?: MultimodalParseResolution;
 };
 
 /**
  * Settings that can be configured for how to use LlamaParse to parse files within a LlamaCloud pipeline.
  */
 export type LlamaParseParameters = {
+  /**
+   * The outbound webhook configurations
+   */
+  webhook_configurations?: Array<WebhookConfiguration> | null;
   /**
    * The priority for the request. This field may be ignored or overwritten depending on the organization tier.
    */
@@ -4623,12 +5176,19 @@ export type LlamaParseParameters = {
   fast_mode?: boolean | null;
   skip_diagonal_text?: boolean | null;
   preserve_layout_alignment_across_pages?: boolean | null;
+  preserve_very_small_text?: boolean | null;
   gpt4o_mode?: boolean | null;
   gpt4o_api_key?: string | null;
   do_not_unroll_columns?: boolean | null;
   extract_layout?: boolean | null;
   high_res_ocr?: boolean | null;
   html_make_all_elements_visible?: boolean | null;
+  layout_aware?: boolean | null;
+  specialized_chart_parsing_agentic?: boolean | null;
+  specialized_chart_parsing_plus?: boolean | null;
+  specialized_chart_parsing_efficient?: boolean | null;
+  specialized_image_parsing?: boolean | null;
+  precise_bounding_box?: boolean | null;
   html_remove_navigation_elements?: boolean | null;
   html_remove_fixed_elements?: boolean | null;
   guess_xlsx_sheet_name?: boolean | null;
@@ -4678,6 +5238,8 @@ export type LlamaParseParameters = {
   complemental_formatting_instruction?: string | null;
   content_guideline_instruction?: string | null;
   spreadsheet_extract_sub_tables?: boolean | null;
+  spreadsheet_force_formula_computation?: boolean | null;
+  inline_images_in_markdown?: boolean | null;
   job_timeout_in_seconds?: number | null;
   job_timeout_extra_time_per_page_in_seconds?: number | null;
   strict_mode_image_extraction?: boolean | null;
@@ -4917,6 +5479,33 @@ export type ManagedIngestionStatusResponse = {
   effective_at?: string | null;
 };
 
+export type ManagedOpenAiEmbedding = {
+  /**
+   * The name of the OpenAI embedding model.
+   */
+  model_name?: "openai-text-embedding-3-small";
+  /**
+   * The batch size for embedding calls.
+   */
+  embed_batch_size?: number;
+  /**
+   * The number of workers to use for async embedding calls.
+   */
+  num_workers?: number | null;
+  class_name?: string;
+};
+
+export type ManagedOpenAiEmbeddingConfig = {
+  /**
+   * Type of the embedding model.
+   */
+  type?: "MANAGED_OPENAI_EMBEDDING";
+  /**
+   * Configuration for the Managed OpenAI embedding model.
+   */
+  component?: ManagedOpenAiEmbedding;
+};
+
 export type MessageAnnotation = {
   type: string;
   data: string;
@@ -4988,6 +5577,13 @@ export type MetronomeDashboardType = "invoices" | "usage";
 export const MetronomeDashboardType = {
   INVOICES: "invoices",
   USAGE: "usage",
+} as const;
+
+export type MultimodalParseResolution = "medium" | "high";
+
+export const MultimodalParseResolution = {
+  MEDIUM: "medium",
+  HIGH: "high",
 } as const;
 
 /**
@@ -5133,6 +5729,12 @@ export type Organization = {
    * Whether the organization is a Parse Premium customer.
    */
   parse_plan_level?: ParsePlanLevel;
+  /**
+   * Feature flags for the organization.
+   */
+  feature_flags?: {
+    [key: string]: unknown;
+  } | null;
 };
 
 /**
@@ -5153,6 +5755,12 @@ export type OrganizationUpdate = {
    * A name for the organization.
    */
   name: string;
+  /**
+   * Feature flags for the organization.
+   */
+  feature_flags?: {
+    [key: string]: unknown;
+  } | null;
 };
 
 /**
@@ -5377,13 +5985,6 @@ export type PaginatedListPipelineFilesResponse = {
   total_count: number;
 };
 
-export type PaginatedReportResponse = {
-  report_responses: Array<ReportResponse>;
-  limit: number;
-  offset: number;
-  total_count: number;
-};
-
 export type PaginatedResponseAgentData = {
   /**
    * The list of items.
@@ -5414,10 +6015,189 @@ export type PaginatedResponseAggregateGroup = {
   total_size?: number | null;
 };
 
+export type PaginatedResponseClassifyJob = {
+  /**
+   * The list of items.
+   */
+  items: Array<ClassifyJob>;
+  /**
+   * A token, which can be sent as page_token to retrieve the next page. If this field is omitted, there are no subsequent pages.
+   */
+  next_page_token?: string | null;
+  /**
+   * The total number of items available. This is only populated when specifically requested. The value may be an estimate and can be used for display purposes only.
+   */
+  total_size?: number | null;
+};
+
+export type PaginatedResponseQuotaConfiguration = {
+  total: number;
+  page: number;
+  size: number;
+  pages: number;
+  items: Array<QuotaConfiguration>;
+};
+
+/**
+ * Parse configuration schema.
+ */
+export type ParseConfiguration = {
+  /**
+   * Unique identifier for the parse configuration
+   */
+  id: string;
+  /**
+   * Name of the parse configuration
+   */
+  name: string;
+  /**
+   * Type of the source (e.g., 'project')
+   */
+  source_type: string;
+  /**
+   * ID of the source
+   */
+  source_id: string;
+  /**
+   * Creator of the configuration
+   */
+  creator?: string | null;
+  /**
+   * Version of the configuration
+   */
+  version: string;
+  /**
+   * LlamaParseParameters configuration
+   */
+  parameters: LlamaParseParameters;
+  /**
+   * Creation timestamp
+   */
+  created_at: string;
+  /**
+   * Last update timestamp
+   */
+  updated_at: string;
+};
+
+/**
+ * Schema for creating a new parse configuration (API boundary).
+ */
+export type ParseConfigurationCreate = {
+  /**
+   * Name of the parse configuration
+   */
+  name: string;
+  /**
+   * Type of the source (e.g., 'project')
+   */
+  source_type?: string | null;
+  /**
+   * ID of the source
+   */
+  source_id?: string | null;
+  /**
+   * Creator of the configuration
+   */
+  creator?: string | null;
+  /**
+   * Version of the configuration
+   */
+  version: string;
+  /**
+   * LlamaParseParameters configuration
+   */
+  parameters: LlamaParseParameters;
+};
+
+/**
+ * Filter parameters for parse configuration queries.
+ */
+export type ParseConfigurationFilter = {
+  /**
+   * Filter by name
+   */
+  name?: string | null;
+  /**
+   * Filter by source type
+   */
+  source_type?: string | null;
+  /**
+   * Filter by source ID
+   */
+  source_id?: string | null;
+  /**
+   * Filter by creator
+   */
+  creator?: string | null;
+  /**
+   * Filter by version
+   */
+  version?: string | null;
+  /**
+   * Filter by specific parse configuration IDs
+   */
+  parse_config_ids?: Array<string> | null;
+};
+
+/**
+ * Request schema for querying parse configurations with pagination and filtering.
+ */
+export type ParseConfigurationQueryRequest = {
+  /**
+   * The maximum number of items to return. The service may return fewer than this value. If unspecified, a default page size will be used. The maximum value is typically 1000; values above this will be coerced to the maximum.
+   */
+  page_size?: number | null;
+  /**
+   * A page token, received from a previous list call. Provide this to retrieve the subsequent page.
+   */
+  page_token?: string | null;
+  /**
+   * A filter object or expression that filters resources listed in the response.
+   */
+  filter?: ParseConfigurationFilter | null;
+  /**
+   * A comma-separated list of fields to order by, sorted in ascending order. Use 'field_name desc' to specify descending order.
+   */
+  order_by?: string | null;
+};
+
+/**
+ * Response schema for paginated parse configuration queries.
+ */
+export type ParseConfigurationQueryResponse = {
+  /**
+   * The list of items.
+   */
+  items: Array<ParseConfiguration>;
+  /**
+   * A token, which can be sent as page_token to retrieve the next page. If this field is omitted, there are no subsequent pages.
+   */
+  next_page_token?: string | null;
+  /**
+   * The total number of items available. This is only populated when specifically requested. The value may be an estimate and can be used for display purposes only.
+   */
+  total_size?: number | null;
+};
+
+/**
+ * Schema for updating an existing parse configuration.
+ */
+export type ParseConfigurationUpdate = {
+  /**
+   * Updated LlamaParseParameters configuration
+   */
+  parameters?: LlamaParseParameters | null;
+};
+
 /**
  * Configuration for llamaparse job
  */
 export type ParseJobConfig = {
+  /**
+   * The outbound webhook configurations
+   */
+  webhook_configurations?: Array<WebhookConfiguration> | null;
   /**
    * The priority for the request. This field may be ignored or overwritten depending on the organization tier.
    */
@@ -5450,12 +6230,19 @@ export type ParseJobConfig = {
   fast_mode?: boolean | null;
   skip_diagonal_text?: boolean | null;
   preserve_layout_alignment_across_pages?: boolean | null;
+  preserve_very_small_text?: boolean | null;
   gpt4o_mode?: boolean | null;
   gpt4o_api_key?: string | null;
   do_not_unroll_columns?: boolean | null;
   extract_layout?: boolean | null;
   high_res_ocr?: boolean | null;
   html_make_all_elements_visible?: boolean | null;
+  layout_aware?: boolean | null;
+  specialized_chart_parsing_agentic?: boolean | null;
+  specialized_chart_parsing_plus?: boolean | null;
+  specialized_chart_parsing_efficient?: boolean | null;
+  specialized_image_parsing?: boolean | null;
+  precise_bounding_box?: boolean | null;
   html_remove_navigation_elements?: boolean | null;
   html_remove_fixed_elements?: boolean | null;
   guess_xlsx_sheet_name?: boolean | null;
@@ -5517,6 +6304,8 @@ export type ParseJobConfig = {
   complemental_formatting_instruction?: string | null;
   content_guideline_instruction?: string | null;
   spreadsheet_extract_sub_tables?: boolean | null;
+  spreadsheet_force_formula_computation?: boolean | null;
+  inline_images_in_markdown?: boolean | null;
   job_timeout_in_seconds?: number | null;
   job_timeout_extra_time_per_page_in_seconds?: number | null;
   strict_mode_image_extraction?: boolean | null;
@@ -5937,6 +6726,10 @@ export type PipelineReadable = {
    */
   embedding_model_config_id?: string | null;
   /**
+   * The embedding model configuration for this pipeline.
+   */
+  embedding_model_config?: EmbeddingModelConfig | null;
+  /**
    * Type of pipeline. Either PLAYGROUND or MANAGED.
    */
   pipeline_type?: PipelineType;
@@ -5945,6 +6738,9 @@ export type PipelineReadable = {
    */
   managed_pipeline_id?: string | null;
   embedding_config:
+    | ({
+        type: "MANAGED_OPENAI_EMBEDDING";
+      } & ManagedOpenAiEmbeddingConfig)
     | ({
         type: "AZURE_EMBEDDING";
       } & AzureOpenAiEmbeddingConfig)
@@ -5966,6 +6762,10 @@ export type PipelineReadable = {
     | ({
         type: "BEDROCK_EMBEDDING";
       } & BedrockEmbeddingConfig);
+  /**
+   * Configuration for the sparse model used in hybrid search.
+   */
+  sparse_model_config?: SparseModelConfig | null;
   /**
    * Hashes for the configuration of the pipeline.
    */
@@ -6023,6 +6823,10 @@ export type PipelineWritable = {
    */
   embedding_model_config_id?: string | null;
   /**
+   * The embedding model configuration for this pipeline.
+   */
+  embedding_model_config?: EmbeddingModelConfig | null;
+  /**
    * Type of pipeline. Either PLAYGROUND or MANAGED.
    */
   pipeline_type?: PipelineType;
@@ -6031,6 +6835,9 @@ export type PipelineWritable = {
    */
   managed_pipeline_id?: string | null;
   embedding_config:
+    | ({
+        type: "MANAGED_OPENAI_EMBEDDING";
+      } & ManagedOpenAiEmbeddingConfig)
     | ({
         type: "AZURE_EMBEDDING";
       } & AzureOpenAiEmbeddingConfig)
@@ -6052,6 +6859,10 @@ export type PipelineWritable = {
     | ({
         type: "BEDROCK_EMBEDDING";
       } & BedrockEmbeddingConfig);
+  /**
+   * Configuration for the sparse model used in hybrid search.
+   */
+  sparse_model_config?: SparseModelConfig | null;
   /**
    * Hashes for the configuration of the pipeline.
    */
@@ -6138,6 +6949,10 @@ export type PipelineCreateReadable = {
    */
   transform_config?: AutoTransformConfig | AdvancedModeTransformConfig | null;
   /**
+   * Configuration for the sparse model used in hybrid search.
+   */
+  sparse_model_config?: SparseModelConfig | null;
+  /**
    * Data sink ID. When provided instead of data_sink, the data sink will be looked up by ID.
    */
   data_sink_id?: string | null;
@@ -6210,6 +7025,10 @@ export type PipelineCreateWritable = {
    * Configuration for the transformation.
    */
   transform_config?: AutoTransformConfig | AdvancedModeTransformConfig | null;
+  /**
+   * Configuration for the sparse model used in hybrid search.
+   */
+  sparse_model_config?: SparseModelConfig | null;
   /**
    * Data sink ID. When provided instead of data_sink, the data sink will be looked up by ID.
    */
@@ -6301,6 +7120,7 @@ export type PipelineDataSourceReadable = {
     | CloudNotionPageDataSourceReadable
     | CloudConfluenceDataSourceReadable
     | CloudJiraDataSourceReadable
+    | CloudJiraDataSourceV2Readable
     | CloudBoxDataSourceReadable;
   /**
    * Version metadata for the data source
@@ -6390,6 +7210,7 @@ export type PipelineDataSourceWritable = {
     | CloudNotionPageDataSourceWritable
     | CloudConfluenceDataSourceWritable
     | CloudJiraDataSourceWritable
+    | CloudJiraDataSourceV2Writable
     | CloudBoxDataSourceWritable;
   /**
    * Version metadata for the data source
@@ -6495,6 +7316,9 @@ export type PipelineFile = {
    * Update datetime
    */
   updated_at?: string | null;
+  /**
+   * Name of the file
+   */
   name?: string | null;
   /**
    * The ID of the file in the external system
@@ -6511,11 +7335,19 @@ export type PipelineFile = {
   /**
    * The ID of the project that the file belongs to
    */
-  project_id: string;
+  project_id?: string | null;
   /**
    * The last modified time of the file
    */
   last_modified_at?: string | null;
+  /**
+   * The ID of the file
+   */
+  file_id?: string | null;
+  /**
+   * The ID of the pipeline that the file is associated with
+   */
+  pipeline_id: string;
   /**
    * Resource information for the file
    */
@@ -6547,18 +7379,6 @@ export type PipelineFile = {
       | null;
   } | null;
   /**
-   * The ID of the data source that the file belongs to
-   */
-  data_source_id?: string | null;
-  /**
-   * The ID of the file
-   */
-  file_id?: string | null;
-  /**
-   * The ID of the pipeline that the file is associated with
-   */
-  pipeline_id: string;
-  /**
    * Custom metadata for the file
    */
   custom_metadata?: {
@@ -6573,6 +7393,10 @@ export type PipelineFile = {
       | boolean
       | null;
   } | null;
+  /**
+   * The ID of the data source that the file belongs to
+   */
+  data_source_id?: string | null;
   /**
    * Hashes for the configuration of the pipeline.
    */
@@ -6781,6 +7605,10 @@ export type PipelineUpdateReadable = {
    */
   transform_config?: AutoTransformConfig | AdvancedModeTransformConfig | null;
   /**
+   * Configuration for the sparse model used in hybrid search.
+   */
+  sparse_model_config?: SparseModelConfig | null;
+  /**
    * Data sink ID. When provided instead of data_sink, the data sink will be looked up by ID.
    */
   data_sink_id?: string | null;
@@ -6802,6 +7630,7 @@ export type PipelineUpdateReadable = {
   eval_parameters?: EvalExecutionParams | null;
   /**
    * Settings that can be configured for how to use LlamaParse to parse files within a LlamaCloud pipeline.
+   * @deprecated
    */
   llama_parse_parameters?: LlamaParseParameters | null;
   /**
@@ -6853,6 +7682,10 @@ export type PipelineUpdateWritable = {
    */
   transform_config?: AutoTransformConfig | AdvancedModeTransformConfig | null;
   /**
+   * Configuration for the sparse model used in hybrid search.
+   */
+  sparse_model_config?: SparseModelConfig | null;
+  /**
    * Data sink ID. When provided instead of data_sink, the data sink will be looked up by ID.
    */
   data_sink_id?: string | null;
@@ -6874,6 +7707,7 @@ export type PipelineUpdateWritable = {
   eval_parameters?: EvalExecutionParams | null;
   /**
    * Settings that can be configured for how to use LlamaParse to parse files within a LlamaCloud pipeline.
+   * @deprecated
    */
   llama_parse_parameters?: LlamaParseParameters | null;
   /**
@@ -6954,7 +7788,7 @@ export type PlaygroundSession = {
   /**
    * Chat message history for this session.
    */
-  chat_messages?: Array<SrcAppSchemaChatChatMessage>;
+  chat_messages?: Array<ChatMessage>;
 };
 
 /**
@@ -7079,41 +7913,6 @@ export type PresignedUrl = {
 };
 
 /**
- * Event for tracking progress of operations in workflows.
- */
-export type ProgressEvent = {
-  timestamp?: string;
-  /**
-   * The ID of the event
-   */
-  id?: string;
-  /**
-   * The ID of the group this event belongs to
-   */
-  group_id?: string;
-  type?: "progress";
-  variant: ReportEventType;
-  /**
-   * The message to display to the user
-   */
-  msg: string;
-  /**
-   * Progress value between 0-1 if available
-   */
-  progress?: number | null;
-  /**
-   * Current status of the operation
-   */
-  status?: "pending" | "in_progress" | "completed" | "error";
-  /**
-   * Any extra details to display to the user
-   */
-  extra_detail?: {
-    [key: string]: unknown;
-  } | null;
-};
-
-/**
  * Schema for a project.
  */
 export type Project = {
@@ -7184,6 +7983,132 @@ export type PromptConf = {
   scratchpad_prompt?: string;
 };
 
+export type PublicModelName =
+  | "openai-gpt-4o"
+  | "openai-gpt-4o-mini"
+  | "openai-gpt-4-1"
+  | "openai-gpt-4-1-mini"
+  | "openai-gpt-4-1-nano"
+  | "openai-gpt-5"
+  | "openai-gpt-5-mini"
+  | "openai-gpt-5-nano"
+  | "openai-text-embedding-3-small"
+  | "openai-text-embedding-3-large"
+  | "openai-whisper-1"
+  | "anthropic-sonnet-3.5"
+  | "anthropic-sonnet-3.5-v2"
+  | "anthropic-sonnet-3.7"
+  | "anthropic-sonnet-4.0"
+  | "gemini-2.5-flash"
+  | "gemini-2.5-pro"
+  | "gemini-2.0-flash"
+  | "gemini-2.0-flash-lite"
+  | "gemini-1.5-flash"
+  | "gemini-1.5-pro";
+
+export const PublicModelName = {
+  OPENAI_GPT_4O: "openai-gpt-4o",
+  OPENAI_GPT_4O_MINI: "openai-gpt-4o-mini",
+  OPENAI_GPT_4_1: "openai-gpt-4-1",
+  OPENAI_GPT_4_1_MINI: "openai-gpt-4-1-mini",
+  OPENAI_GPT_4_1_NANO: "openai-gpt-4-1-nano",
+  OPENAI_GPT_5: "openai-gpt-5",
+  OPENAI_GPT_5_MINI: "openai-gpt-5-mini",
+  OPENAI_GPT_5_NANO: "openai-gpt-5-nano",
+  OPENAI_TEXT_EMBEDDING_3_SMALL: "openai-text-embedding-3-small",
+  OPENAI_TEXT_EMBEDDING_3_LARGE: "openai-text-embedding-3-large",
+  OPENAI_WHISPER_1: "openai-whisper-1",
+  ANTHROPIC_SONNET_3_5: "anthropic-sonnet-3.5",
+  ANTHROPIC_SONNET_3_5_V2: "anthropic-sonnet-3.5-v2",
+  ANTHROPIC_SONNET_3_7: "anthropic-sonnet-3.7",
+  ANTHROPIC_SONNET_4_0: "anthropic-sonnet-4.0",
+  GEMINI_2_5_FLASH: "gemini-2.5-flash",
+  GEMINI_2_5_PRO: "gemini-2.5-pro",
+  GEMINI_2_0_FLASH: "gemini-2.0-flash",
+  GEMINI_2_0_FLASH_LITE: "gemini-2.0-flash-lite",
+  GEMINI_1_5_FLASH: "gemini-1.5-flash",
+  GEMINI_1_5_PRO: "gemini-1.5-pro",
+} as const;
+
+/**
+ * Full quota configuration model.
+ */
+export type QuotaConfiguration = {
+  /**
+   * The source type, e.g. 'organization'
+   */
+  source_type: "organization";
+  /**
+   * The source ID, e.g. the organization ID
+   */
+  source_id: string;
+  /**
+   * The quota configuration type
+   */
+  configuration_type:
+    | "rate_limit_parse_concurrent_premium"
+    | "rate_limit_parse_concurrent_default"
+    | "rate_limit_concurrent_jobs_in_execution_default"
+    | "rate_limit_concurrent_jobs_in_execution_doc_ingest"
+    | "limit_embedding_character";
+  /**
+   * The quota configuration value
+   */
+  configuration_value: QuotaRateLimitConfigurationValue;
+  /**
+   * The configuration metadata
+   */
+  configuration_metadata: {
+    [key: string]: unknown;
+  } | null;
+  /**
+   * The start date of the quota
+   */
+  started_at?: string;
+  /**
+   * The end date of the quota
+   */
+  ended_at?: string | null;
+  /**
+   * The idempotency key
+   */
+  idempotency_key?: string | null;
+  /**
+   * The status of the quota, i.e. 'ACTIVE' or 'INACTIVE'
+   */
+  status: "ACTIVE" | "INACTIVE";
+  /**
+   * The system-generated UUID for the quota
+   */
+  id?: string | null;
+  /**
+   * The creation date of the quota configuration in the database
+   */
+  created_at?: string | null;
+  /**
+   * The last updated date of the quota configuration in the database
+   */
+  updated_at?: string | null;
+};
+
+/**
+ * Quota-specific wrapper for default rate limit configuration.
+ */
+export type QuotaRateLimitConfigurationValue = {
+  /**
+   * The rate numerator
+   */
+  numerator: number;
+  /**
+   * The rate limit denominator
+   */
+  denominator?: number | null;
+  /**
+   * The default rate limit denominator units
+   */
+  denominator_units?: ("second" | "minute" | "hour" | "day") | null;
+};
+
 export type ReRankConfig = {
   /**
    * The number of nodes to retrieve after reranking over retrieved nodes from all retrieval tools.
@@ -7247,237 +8172,11 @@ export type RelatedNodeInfo = {
   class_name?: string;
 };
 
-export type Report = {
+export type Restrict = {
   /**
-   * The id of the report
+   * The project ID to restrict the user to.
    */
-  id: string;
-  /**
-   * The blocks of the report
-   */
-  blocks?: Array<ReportBlock>;
-};
-
-export type ReportBlock = {
-  /**
-   * The index of the block
-   */
-  idx: number;
-  /**
-   * The content of the block
-   */
-  template: string;
-  /**
-   * Whether the block requires human review
-   */
-  requires_human_review?: boolean;
-  /**
-   * The sources for the block
-   */
-  sources?: Array<TextNodeWithScore>;
-};
-
-export type ReportBlockDependency = "none" | "all" | "previous" | "next";
-
-export const ReportBlockDependency = {
-  NONE: "none",
-  ALL: "all",
-  PREVIOUS: "previous",
-  NEXT: "next",
-} as const;
-
-export type ReportCreateResponse = {
-  /**
-   * The id of the report
-   */
-  id: string;
-};
-
-/**
- * From backend schema
- */
-export type ReportEventItem = {
-  /**
-   * The id of the event
-   */
-  id: string;
-  /**
-   * The id of the report
-   */
-  report_id: string;
-  /**
-   * The type of the event
-   */
-  event_type: string;
-  /**
-   * The data for the event
-   */
-  event_data: ProgressEvent | ReportUpdateEvent | ReportStateEvent;
-  /**
-   * The timestamp for the event
-   */
-  timestamp: string;
-};
-
-export type ReportEventType =
-  | "load_template"
-  | "extract_plan"
-  | "summarize"
-  | "file_processing"
-  | "generate_block"
-  | "editing";
-
-export const ReportEventType = {
-  LOAD_TEMPLATE: "load_template",
-  EXTRACT_PLAN: "extract_plan",
-  SUMMARIZE: "summarize",
-  FILE_PROCESSING: "file_processing",
-  GENERATE_BLOCK: "generate_block",
-  EDITING: "editing",
-} as const;
-
-/**
- * Used to update the metadata of a report.
- */
-export type ReportMetadata = {
-  /**
-   * The id of the report
-   */
-  id: string;
-  /**
-   * The name of the report
-   */
-  name: string;
-  /**
-   * The metadata for the report
-   */
-  report_metadata: {
-    [key: string]: unknown;
-  };
-  /**
-   * The state of the report
-   */
-  state: ReportState;
-  input_files?: Array<string> | null;
-  template_file?: string | null;
-  template_text?: string | null;
-  template_instructions?: string | null;
-};
-
-export type ReportNameUpdate = {
-  /**
-   * The name of the report
-   */
-  name: string;
-};
-
-export type ReportPlan = {
-  /**
-   * The id of the report plan
-   */
-  id?: string;
-  /**
-   * The blocks of the report
-   */
-  blocks?: Array<ReportPlanBlock>;
-  /**
-   * The timestamp of when the plan was generated
-   */
-  generated_at?: string;
-};
-
-export type ReportPlanBlock = {
-  block: ReportBlock;
-  /**
-   * The queries for the block
-   */
-  queries?: Array<ReportQuery>;
-  /**
-   * The dependency for the block
-   */
-  dependency: ReportBlockDependency;
-};
-
-export type ReportQuery = {
-  /**
-   * The field in the template that needs to be filled in
-   */
-  field: string;
-  /**
-   * The prompt for filling in the field
-   */
-  prompt: string;
-  /**
-   * Any additional context for the query
-   */
-  context: string;
-};
-
-export type ReportResponse = {
-  name: string;
-  report_id: string;
-  report: Report | null;
-  plan: ReportPlan | null;
-  version: number;
-  last_updated: string;
-  status: ReportState;
-  total_versions: number;
-};
-
-export type ReportState =
-  | "pending"
-  | "planning"
-  | "waiting_approval"
-  | "generating"
-  | "completed"
-  | "error";
-
-export const ReportState = {
-  PENDING: "pending",
-  PLANNING: "planning",
-  WAITING_APPROVAL: "waiting_approval",
-  GENERATING: "generating",
-  COMPLETED: "completed",
-  ERROR: "error",
-} as const;
-
-/**
- * Event for notifying when an report's state changes.
- */
-export type ReportStateEvent = {
-  timestamp?: string;
-  type: "report_state_update";
-  /**
-   * The message to display to the user
-   */
-  msg: string;
-  /**
-   * The new state of the report
-   */
-  status: ReportState;
-};
-
-/**
- * Event for updating the state of an report.
- */
-export type ReportUpdateEvent = {
-  timestamp?: string;
-  type?: "report_block_update";
-  /**
-   * The message to display to the user
-   */
-  msg?: string;
-  /**
-   * The block to update
-   */
-  block: ReportBlock;
-};
-
-export type ReportVersionPatch = {
-  /**
-   * The content of the report version
-   */
-  content: Report;
+  project_id: string | null;
 };
 
 export type RetrievalMode =
@@ -7736,7 +8435,7 @@ export type SearchRequest = {
    */
   order_by?: string | null;
   /**
-   * The agent deployment's deployment_name to search within
+   * The agent deployment's name to search within
    */
   deployment_name: string;
   /**
@@ -7766,6 +8465,42 @@ export type SentenceChunkingConfig = {
   separator?: string;
   paragraph_separator?: string;
 };
+
+/**
+ * Configuration for sparse embedding models used in hybrid search.
+ *
+ * This allows users to choose between Splade and BM25 models for
+ * sparse retrieval in managed data sinks.
+ */
+export type SparseModelConfig = {
+  /**
+   * The sparse model type to use. 'auto' selects based on deployment mode (BYOC uses term frequency, Cloud uses Splade), 'splade' uses HuggingFace Splade model, 'bm25' uses Qdrant's FastEmbed BM25 model.
+   */
+  model_type?: SparseModelType;
+  class_name?: string;
+};
+
+/**
+ * Enum for sparse model types supported in LlamaCloud.
+ *
+ * SPLADE: Uses HuggingFace Splade model for sparse embeddings
+ * BM25: Uses Qdrant's FastEmbed BM25 model for sparse embeddings
+ * AUTO: Automatically selects based on deployment mode (BYOC uses term frequency, Cloud uses Splade)
+ */
+export type SparseModelType = "splade" | "bm25" | "auto";
+
+/**
+ * Enum for sparse model types supported in LlamaCloud.
+ *
+ * SPLADE: Uses HuggingFace Splade model for sparse embeddings
+ * BM25: Uses Qdrant's FastEmbed BM25 model for sparse embeddings
+ * AUTO: Automatically selects based on deployment mode (BYOC uses term frequency, Cloud uses Splade)
+ */
+export const SparseModelType = {
+  SPLADE: "splade",
+  BM25: "bm25",
+  AUTO: "auto",
+} as const;
 
 /**
  * Enum for representing the status of a job
@@ -7824,6 +8559,10 @@ export type StructParseConf = {
    */
   struct_mode?: StructMode;
   /**
+   * Whether to fetch logprobs for the structured parsing.
+   */
+  fetch_logprobs?: boolean;
+  /**
    * Whether to handle missing fields in the schema.
    */
   handle_missing?: boolean;
@@ -7867,6 +8606,9 @@ export type SupportedLlmModelNames =
   | "GPT_4_1_MINI"
   | "AZURE_OPENAI_GPT_4O"
   | "AZURE_OPENAI_GPT_4O_MINI"
+  | "AZURE_OPENAI_GPT_4_1"
+  | "AZURE_OPENAI_GPT_4_1_MINI"
+  | "AZURE_OPENAI_GPT_4_1_NANO"
   | "CLAUDE_3_5_SONNET"
   | "BEDROCK_CLAUDE_3_5_SONNET_V1"
   | "BEDROCK_CLAUDE_3_5_SONNET_V2"
@@ -7880,16 +8622,14 @@ export const SupportedLlmModelNames = {
   GPT_4_1_MINI: "GPT_4_1_MINI",
   AZURE_OPENAI_GPT_4O: "AZURE_OPENAI_GPT_4O",
   AZURE_OPENAI_GPT_4O_MINI: "AZURE_OPENAI_GPT_4O_MINI",
+  AZURE_OPENAI_GPT_4_1: "AZURE_OPENAI_GPT_4_1",
+  AZURE_OPENAI_GPT_4_1_MINI: "AZURE_OPENAI_GPT_4_1_MINI",
+  AZURE_OPENAI_GPT_4_1_NANO: "AZURE_OPENAI_GPT_4_1_NANO",
   CLAUDE_3_5_SONNET: "CLAUDE_3_5_SONNET",
   BEDROCK_CLAUDE_3_5_SONNET_V1: "BEDROCK_CLAUDE_3_5_SONNET_V1",
   BEDROCK_CLAUDE_3_5_SONNET_V2: "BEDROCK_CLAUDE_3_5_SONNET_V2",
   VERTEX_AI_CLAUDE_3_5_SONNET_V2: "VERTEX_AI_CLAUDE_3_5_SONNET_V2",
 } as const;
-
-export type TextBlock = {
-  block_type?: "text";
-  text: string;
-};
 
 /**
  * Provided for backward compatibility.
@@ -8001,9 +8741,44 @@ export type UsageResponse = {
     | "plan_spend_limit_soft_alert"
     | "configured_spend_limit_exceeded"
     | "free_credits_exhausted"
+    | "internal_spending_alert"
+    | "has_spending_alert"
   >;
   current_invoice_total_usd_cents?: number | null;
   total_extraction_agents?: number;
+};
+
+export type User = {
+  id: string;
+  email: string;
+  /**
+   * The last login provider.
+   */
+  last_login_provider?: "oidc" | "basic" | "no_auth";
+  /**
+   * The user's name.
+   */
+  name?: string | null;
+  /**
+   * The user's first name.
+   */
+  first_name?: string | null;
+  /**
+   * The user's last name.
+   */
+  last_name?: string | null;
+  /**
+   * The user's custom claims.
+   */
+  claims?: CustomClaims;
+  /**
+   * The restrictions on the user.
+   */
+  restrict?: Restrict | null;
+  /**
+   * The user's creation date.
+   */
+  created_at?: string | null;
 };
 
 export type UserJobRecord = {
@@ -8268,95 +9043,83 @@ export type WebhookConfiguration = {
     | "extract.error"
     | "extract.partial_success"
     | "extract.cancelled"
+    | "parse.pending"
+    | "parse.success"
+    | "parse.error"
+    | "parse.partial_success"
+    | "parse.cancelled"
     | "unmapped_event"
   > | null;
+  /**
+   * The output format to use for the webhook. Defaults to string if none supplied. Currently supported values: string, json
+   */
+  webhook_output_format?: string | null;
 };
 
-/**
- * Request body for stateless extraction. Must include either file_id, text, or base64.
- */
-export type StatelessExtractionRequest = {
-  data_schema:
-    | {
-        [key: string]:
-          | {
-              [key: string]: unknown;
-            }
-          | Array<unknown>
-          | string
-          | number
-          | number
-          | boolean
-          | null;
-      }
-    | string
-    | null;
-  /**
-   * The configuration parameters for the extraction agent.
-   */
-  config?: ExtractConfig;
-  /**
-   * ID of an uploaded file to extract from
-   */
-  file_id?: string;
-};
-
-/**
- * Chat message.
- */
-export type LlamaIndexCoreBaseLlmsTypesChatMessage = {
-  role?: MessageRole;
-  additional_kwargs?: {
-    [key: string]: unknown;
+export type ListDeploymentsApiV1ProjectsProjectIdAgentsGetData = {
+  body?: never;
+  path: {
+    project_id: string;
   };
-  blocks?: Array<
-    | ({
-        block_type: "text";
-      } & TextBlock)
-    | ({
-        block_type: "image";
-      } & ImageBlock)
-    | ({
-        block_type: "audio";
-      } & AudioBlock)
-    | ({
-        block_type: "document";
-      } & DocumentBlock)
-  >;
+  query?: never;
+  url: "/api/v1/projects/{project_id}/agents";
 };
 
-export type SrcAppSchemaChatChatMessage = {
-  id: string;
+export type ListDeploymentsApiV1ProjectsProjectIdAgentsGetErrors = {
   /**
-   * The index of the message in the chat.
+   * Validation Error
    */
-  index: number;
-  /**
-   * Retrieval annotations for the message.
-   */
-  annotations?: Array<MessageAnnotation>;
-  /**
-   * The role of the message.
-   */
-  role: MessageRole;
-  /**
-   * Text content of the generation
-   */
-  content?: string | null;
-  /**
-   * Additional arguments passed to the model
-   */
-  additional_kwargs?: {
-    [key: string]: string;
-  };
-  class_name?: string;
+  422: HttpValidationError;
 };
+
+export type ListDeploymentsApiV1ProjectsProjectIdAgentsGetError =
+  ListDeploymentsApiV1ProjectsProjectIdAgentsGetErrors[keyof ListDeploymentsApiV1ProjectsProjectIdAgentsGetErrors];
+
+export type ListDeploymentsApiV1ProjectsProjectIdAgentsGetResponses = {
+  /**
+   * Successful Response
+   */
+  200: AgentDeploymentList;
+};
+
+export type ListDeploymentsApiV1ProjectsProjectIdAgentsGetResponse =
+  ListDeploymentsApiV1ProjectsProjectIdAgentsGetResponses[keyof ListDeploymentsApiV1ProjectsProjectIdAgentsGetResponses];
+
+export type SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostData = {
+  body?: never;
+  path: {
+    project_id: string;
+  };
+  query?: never;
+  url: "/api/v1/projects/{project_id}/agents:sync";
+};
+
+export type SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostError =
+  SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostErrors[keyof SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostErrors];
+
+export type SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: AgentDeploymentList;
+};
+
+export type SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponse =
+  SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponses[keyof SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponses];
 
 export type ListKeysApiV1ApiKeysGetData = {
   body?: never;
   path?: never;
   query?: {
     project_id?: string | null;
+    key_type?: ApiKeyType;
   };
   url: "/api/v1/api-keys";
 };
@@ -8436,35 +9199,6 @@ export type DeleteApiKeyApiV1ApiKeysApiKeyIdDeleteResponses = {
 
 export type DeleteApiKeyApiV1ApiKeysApiKeyIdDeleteResponse =
   DeleteApiKeyApiV1ApiKeysApiKeyIdDeleteResponses[keyof DeleteApiKeyApiV1ApiKeysApiKeyIdDeleteResponses];
-
-export type UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutData = {
-  body: ApiKeyUpdate;
-  path: {
-    api_key_id: string;
-  };
-  query?: never;
-  url: "/api/v1/api-keys/{api_key_id}";
-};
-
-export type UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutError =
-  UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutErrors[keyof UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutErrors];
-
-export type UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutResponses = {
-  /**
-   * Successful Response
-   */
-  200: ApiKey;
-};
-
-export type UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutResponse =
-  UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutResponses[keyof UpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutResponses];
 
 export type ValidateEmbeddingConnectionApiV1ValidateIntegrationsValidateEmbeddingConnectionPostData =
   {
@@ -10325,6 +11059,79 @@ export type GetFilePageFigureApiV1FilesIdPageFiguresPageIndexFigureNameGetRespon
     200: unknown;
   };
 
+export type GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostData =
+  {
+    body?: never;
+    path: {
+      id: string;
+      page_index: number;
+    };
+    query?: {
+      project_id?: string | null;
+      organization_id?: string | null;
+    };
+    url: "/api/v1/files/{id}/page_screenshots/{page_index}/presigned_url";
+  };
+
+export type GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostError =
+  GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostErrors[keyof GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostErrors];
+
+export type GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: PresignedUrl;
+  };
+
+export type GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostResponse =
+  GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostResponses[keyof GenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostResponses];
+
+export type GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostData =
+  {
+    body?: never;
+    path: {
+      id: string;
+      page_index: number;
+      figure_name: string;
+    };
+    query?: {
+      project_id?: string | null;
+      organization_id?: string | null;
+    };
+    url: "/api/v1/files/{id}/page-figures/{page_index}/{figure_name}/presigned_url";
+  };
+
+export type GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostError =
+  GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostErrors[keyof GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostErrors];
+
+export type GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: PresignedUrl;
+  };
+
+export type GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostResponse =
+  GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostResponses[keyof GenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostResponses];
+
 export type SearchPipelinesApiV1PipelinesGetData = {
   body?: never;
   path?: never;
@@ -10721,6 +11528,7 @@ export type ListPipelineFiles2ApiV1PipelinesPipelineIdFiles2GetData = {
   query?: {
     data_source_id?: string | null;
     only_manually_uploaded?: boolean;
+    file_name_contains?: string | null;
     limit?: number | null;
     offset?: number | null;
     order_by?: string | null;
@@ -11525,6 +12333,36 @@ export type GetPipelineDocumentStatusApiV1PipelinesPipelineIdDocumentsDocumentId
 export type GetPipelineDocumentStatusApiV1PipelinesPipelineIdDocumentsDocumentIdStatusGetResponse =
   GetPipelineDocumentStatusApiV1PipelinesPipelineIdDocumentsDocumentIdStatusGetResponses[keyof GetPipelineDocumentStatusApiV1PipelinesPipelineIdDocumentsDocumentIdStatusGetResponses];
 
+export type SyncPipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdSyncPostData =
+  {
+    body?: never;
+    path: {
+      document_id: string;
+      pipeline_id: string;
+    };
+    query?: never;
+    url: "/api/v1/pipelines/{pipeline_id}/documents/{document_id}/sync";
+  };
+
+export type SyncPipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdSyncPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type SyncPipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdSyncPostError =
+  SyncPipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdSyncPostErrors[keyof SyncPipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdSyncPostErrors];
+
+export type SyncPipelineDocumentApiV1PipelinesPipelineIdDocumentsDocumentIdSyncPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: unknown;
+  };
+
 export type ListPipelineDocumentChunksApiV1PipelinesPipelineIdDocumentsDocumentIdChunksGetData =
   {
     body?: never;
@@ -11557,6 +12395,41 @@ export type ListPipelineDocumentChunksApiV1PipelinesPipelineIdDocumentsDocumentI
 
 export type ListPipelineDocumentChunksApiV1PipelinesPipelineIdDocumentsDocumentIdChunksGetResponse =
   ListPipelineDocumentChunksApiV1PipelinesPipelineIdDocumentsDocumentIdChunksGetResponses[keyof ListPipelineDocumentChunksApiV1PipelinesPipelineIdDocumentsDocumentIdChunksGetResponses];
+
+export type ForceSyncAllPipelineDocumentsApiV1PipelinesPipelineIdDocumentsForceSyncAllPostData =
+  {
+    body?: never;
+    path: {
+      pipeline_id: string;
+    };
+    query?: {
+      batch_size?: number;
+      /**
+       * Only sync retriable documents (failed/cancelled/not-started/stalled-in-progress)
+       */
+      only_failed?: boolean;
+    };
+    url: "/api/v1/pipelines/{pipeline_id}/documents/force-sync-all";
+  };
+
+export type ForceSyncAllPipelineDocumentsApiV1PipelinesPipelineIdDocumentsForceSyncAllPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type ForceSyncAllPipelineDocumentsApiV1PipelinesPipelineIdDocumentsForceSyncAllPostError =
+  ForceSyncAllPipelineDocumentsApiV1PipelinesPipelineIdDocumentsForceSyncAllPostErrors[keyof ForceSyncAllPipelineDocumentsApiV1PipelinesPipelineIdDocumentsForceSyncAllPostErrors];
+
+export type ForceSyncAllPipelineDocumentsApiV1PipelinesPipelineIdDocumentsForceSyncAllPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    202: unknown;
+  };
 
 export type ListRetrieversApiV1RetrieversGetData = {
   body?: never;
@@ -11817,7 +12690,7 @@ export type GetJobsApiV1JobsGetData = {
     project_id?: string | null;
     organization_id?: string | null;
   };
-  url: "/api/v1/jobs/";
+  url: "/api/v1/jobs";
 };
 
 export type GetJobsApiV1JobsGetErrors = {
@@ -12627,93 +13500,161 @@ export type ChatWithChatAppApiV1AppsIdChatPostResponses = {
   200: unknown;
 };
 
-export type ListDeploymentsApiV1ProjectsProjectIdAgentsGetData = {
+export type ListClassifyJobsApiV1ClassifierJobsGetData = {
   body?: never;
-  path: {
-    project_id: string;
+  path?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+    page_size?: number | null;
+    page_token?: string | null;
   };
-  query?: never;
-  url: "/api/v1/projects/{project_id}/agents";
+  url: "/api/v1/classifier/jobs";
 };
 
-export type ListDeploymentsApiV1ProjectsProjectIdAgentsGetErrors = {
+export type ListClassifyJobsApiV1ClassifierJobsGetErrors = {
   /**
    * Validation Error
    */
   422: HttpValidationError;
 };
 
-export type ListDeploymentsApiV1ProjectsProjectIdAgentsGetError =
-  ListDeploymentsApiV1ProjectsProjectIdAgentsGetErrors[keyof ListDeploymentsApiV1ProjectsProjectIdAgentsGetErrors];
+export type ListClassifyJobsApiV1ClassifierJobsGetError =
+  ListClassifyJobsApiV1ClassifierJobsGetErrors[keyof ListClassifyJobsApiV1ClassifierJobsGetErrors];
 
-export type ListDeploymentsApiV1ProjectsProjectIdAgentsGetResponses = {
+export type ListClassifyJobsApiV1ClassifierJobsGetResponses = {
   /**
    * Successful Response
    */
-  200: AgentDeploymentList;
+  200: PaginatedResponseClassifyJob;
 };
 
-export type ListDeploymentsApiV1ProjectsProjectIdAgentsGetResponse =
-  ListDeploymentsApiV1ProjectsProjectIdAgentsGetResponses[keyof ListDeploymentsApiV1ProjectsProjectIdAgentsGetResponses];
+export type ListClassifyJobsApiV1ClassifierJobsGetResponse =
+  ListClassifyJobsApiV1ClassifierJobsGetResponses[keyof ListClassifyJobsApiV1ClassifierJobsGetResponses];
 
-export type SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostData = {
-  body?: never;
-  path: {
-    project_id: string;
-  };
-  query?: never;
-  url: "/api/v1/projects/{project_id}/agents:sync";
-};
-
-export type SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostError =
-  SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostErrors[keyof SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostErrors];
-
-export type SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: AgentDeploymentList;
-};
-
-export type SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponse =
-  SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponses[keyof SyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponses];
-
-export type ClassifyDocumentsApiV1ClassifierClassifyPostData = {
-  body: BodyClassifyDocumentsApiV1ClassifierClassifyPost;
+export type CreateClassifyJobApiV1ClassifierJobsPostData = {
+  body: ClassifyJobCreate;
   path?: never;
   query?: {
     project_id?: string | null;
     organization_id?: string | null;
   };
-  url: "/api/v1/classifier/classify";
+  url: "/api/v1/classifier/jobs";
 };
 
-export type ClassifyDocumentsApiV1ClassifierClassifyPostErrors = {
+export type CreateClassifyJobApiV1ClassifierJobsPostErrors = {
   /**
    * Validation Error
    */
   422: HttpValidationError;
 };
 
-export type ClassifyDocumentsApiV1ClassifierClassifyPostError =
-  ClassifyDocumentsApiV1ClassifierClassifyPostErrors[keyof ClassifyDocumentsApiV1ClassifierClassifyPostErrors];
+export type CreateClassifyJobApiV1ClassifierJobsPostError =
+  CreateClassifyJobApiV1ClassifierJobsPostErrors[keyof CreateClassifyJobApiV1ClassifierJobsPostErrors];
 
-export type ClassifyDocumentsApiV1ClassifierClassifyPostResponses = {
+export type CreateClassifyJobApiV1ClassifierJobsPostResponses = {
   /**
    * Successful Response
    */
-  200: ClassifyResponse;
+  200: ClassifyJob;
 };
 
-export type ClassifyDocumentsApiV1ClassifierClassifyPostResponse =
-  ClassifyDocumentsApiV1ClassifierClassifyPostResponses[keyof ClassifyDocumentsApiV1ClassifierClassifyPostResponses];
+export type CreateClassifyJobApiV1ClassifierJobsPostResponse =
+  CreateClassifyJobApiV1ClassifierJobsPostResponses[keyof CreateClassifyJobApiV1ClassifierJobsPostResponses];
+
+export type GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetData = {
+  body?: never;
+  path: {
+    classify_job_id: string;
+  };
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
+  url: "/api/v1/classifier/jobs/{classify_job_id}";
+};
+
+export type GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetError =
+  GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetErrors[keyof GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetErrors];
+
+export type GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetResponses = {
+  /**
+   * Successful Response
+   */
+  200: ClassifyJob;
+};
+
+export type GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetResponse =
+  GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetResponses[keyof GetClassifyJobApiV1ClassifierJobsClassifyJobIdGetResponses];
+
+export type GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetData =
+  {
+    body?: never;
+    path: {
+      classify_job_id: string;
+    };
+    query?: {
+      project_id?: string | null;
+      organization_id?: string | null;
+    };
+    url: "/api/v1/classifier/jobs/{classify_job_id}/results";
+  };
+
+export type GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetError =
+  GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetErrors[keyof GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetErrors];
+
+export type GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: ClassifyJobResults;
+  };
+
+export type GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetResponse =
+  GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetResponses[keyof GetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetResponses];
+
+export type ReadSelfApiV1AuthMeGetData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/api/v1/auth/me";
+};
+
+export type ReadSelfApiV1AuthMeGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type ReadSelfApiV1AuthMeGetError =
+  ReadSelfApiV1AuthMeGetErrors[keyof ReadSelfApiV1AuthMeGetErrors];
+
+export type ReadSelfApiV1AuthMeGetResponses = {
+  /**
+   * Successful Response
+   */
+  200: User;
+};
+
+export type ReadSelfApiV1AuthMeGetResponse =
+  ReadSelfApiV1AuthMeGetResponses[keyof ReadSelfApiV1AuthMeGetResponses];
 
 export type CreateCustomerPortalSessionApiV1BillingCustomerPortalSessionPostData =
   {
@@ -12859,6 +13800,10 @@ export type ListExtractionAgentsApiV1ExtractionExtractionAgentsGetData = {
   body?: never;
   path?: never;
   query?: {
+    /**
+     * Whether to include default agents in the results
+     */
+    include_default?: boolean;
     project_id?: string | null;
     organization_id?: string | null;
   };
@@ -13014,6 +13959,39 @@ export type GetExtractionAgentByNameApiV1ExtractionExtractionAgentsByNameNameGet
 export type GetExtractionAgentByNameApiV1ExtractionExtractionAgentsByNameNameGetResponse =
   GetExtractionAgentByNameApiV1ExtractionExtractionAgentsByNameNameGetResponses[keyof GetExtractionAgentByNameApiV1ExtractionExtractionAgentsByNameNameGetResponses];
 
+export type GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetData =
+  {
+    body?: never;
+    path?: never;
+    query?: {
+      project_id?: string | null;
+      organization_id?: string | null;
+    };
+    url: "/api/v1/extraction/extraction-agents/default";
+  };
+
+export type GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetError =
+  GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetErrors[keyof GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetErrors];
+
+export type GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: ExtractAgent;
+  };
+
+export type GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetResponse =
+  GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetResponses[keyof GetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetResponses];
+
 export type DeleteExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentIdDeleteData =
   {
     body?: never;
@@ -13106,33 +14084,6 @@ export type UpdateExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentI
 
 export type UpdateExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentIdPutResponse =
   UpdateExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentIdPutResponses[keyof UpdateExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentIdPutResponses];
-
-export type ExtractStatelessApiV1ExtractionRunPostData = {
-  body: StatelessExtractionRequest;
-  path?: never;
-  query?: never;
-  url: "/api/v1/extraction/run";
-};
-
-export type ExtractStatelessApiV1ExtractionRunPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type ExtractStatelessApiV1ExtractionRunPostError =
-  ExtractStatelessApiV1ExtractionRunPostErrors[keyof ExtractStatelessApiV1ExtractionRunPostErrors];
-
-export type ExtractStatelessApiV1ExtractionRunPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: ExtractJob;
-};
-
-export type ExtractStatelessApiV1ExtractionRunPostResponse =
-  ExtractStatelessApiV1ExtractionRunPostResponses[keyof ExtractStatelessApiV1ExtractionRunPostResponses];
 
 export type ListJobsApiV1ExtractionJobsGetData = {
   body?: never;
@@ -13493,390 +14444,153 @@ export type GetRunApiV1ExtractionRunsRunIdGetResponses = {
 export type GetRunApiV1ExtractionRunsRunIdGetResponse =
   GetRunApiV1ExtractionRunsRunIdGetResponses[keyof GetRunApiV1ExtractionRunsRunIdGetResponses];
 
-export type CreateReportApiV1ReportsPostData = {
-  body: BodyCreateReportApiV1ReportsPost;
+export type ExtractStatelessApiV1ExtractionRunPostData = {
+  body: ExtractStatelessRequest;
   path?: never;
   query?: {
     project_id?: string | null;
     organization_id?: string | null;
   };
-  url: "/api/v1/reports/";
+  url: "/api/v1/extraction/run";
 };
 
-export type CreateReportApiV1ReportsPostErrors = {
+export type ExtractStatelessApiV1ExtractionRunPostErrors = {
   /**
    * Validation Error
    */
   422: HttpValidationError;
 };
 
-export type CreateReportApiV1ReportsPostError =
-  CreateReportApiV1ReportsPostErrors[keyof CreateReportApiV1ReportsPostErrors];
+export type ExtractStatelessApiV1ExtractionRunPostError =
+  ExtractStatelessApiV1ExtractionRunPostErrors[keyof ExtractStatelessApiV1ExtractionRunPostErrors];
 
-export type CreateReportApiV1ReportsPostResponses = {
+export type ExtractStatelessApiV1ExtractionRunPostResponses = {
   /**
    * Successful Response
    */
-  200: ReportCreateResponse;
+  200: ExtractJob;
 };
 
-export type CreateReportApiV1ReportsPostResponse =
-  CreateReportApiV1ReportsPostResponses[keyof CreateReportApiV1ReportsPostResponses];
+export type ExtractStatelessApiV1ExtractionRunPostResponse =
+  ExtractStatelessApiV1ExtractionRunPostResponses[keyof ExtractStatelessApiV1ExtractionRunPostResponses];
 
-export type ListReportsApiV1ReportsListGetData = {
+export type ListApiKeysApiV1BetaApiKeysGetData = {
   body?: never;
   path?: never;
   query?: {
-    state?: ReportState | null;
-    limit?: number;
-    offset?: number;
+    page_size?: number | null;
+    page_token?: string | null;
+    name?: string | null;
     project_id?: string | null;
-    organization_id?: string | null;
+    key_type?: ApiKeyType | null;
   };
-  url: "/api/v1/reports/list";
+  url: "/api/v1/beta/api-keys";
 };
 
-export type ListReportsApiV1ReportsListGetErrors = {
+export type ListApiKeysApiV1BetaApiKeysGetErrors = {
   /**
    * Validation Error
    */
   422: HttpValidationError;
 };
 
-export type ListReportsApiV1ReportsListGetError =
-  ListReportsApiV1ReportsListGetErrors[keyof ListReportsApiV1ReportsListGetErrors];
+export type ListApiKeysApiV1BetaApiKeysGetError =
+  ListApiKeysApiV1BetaApiKeysGetErrors[keyof ListApiKeysApiV1BetaApiKeysGetErrors];
 
-export type ListReportsApiV1ReportsListGetResponses = {
+export type ListApiKeysApiV1BetaApiKeysGetResponses = {
   /**
    * Successful Response
    */
-  200: PaginatedReportResponse;
+  200: ApiKeyQueryResponse;
 };
 
-export type ListReportsApiV1ReportsListGetResponse =
-  ListReportsApiV1ReportsListGetResponses[keyof ListReportsApiV1ReportsListGetResponses];
+export type ListApiKeysApiV1BetaApiKeysGetResponse =
+  ListApiKeysApiV1BetaApiKeysGetResponses[keyof ListApiKeysApiV1BetaApiKeysGetResponses];
 
-export type DeleteReportApiV1ReportsReportIdDeleteData = {
+export type CreateApiKeyApiV1BetaApiKeysPostData = {
+  body: ApiKeyCreate;
+  path?: never;
+  query?: never;
+  url: "/api/v1/beta/api-keys";
+};
+
+export type CreateApiKeyApiV1BetaApiKeysPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CreateApiKeyApiV1BetaApiKeysPostError =
+  CreateApiKeyApiV1BetaApiKeysPostErrors[keyof CreateApiKeyApiV1BetaApiKeysPostErrors];
+
+export type CreateApiKeyApiV1BetaApiKeysPostResponses = {
+  /**
+   * Successful Response
+   */
+  201: ApiKey;
+};
+
+export type CreateApiKeyApiV1BetaApiKeysPostResponse =
+  CreateApiKeyApiV1BetaApiKeysPostResponses[keyof CreateApiKeyApiV1BetaApiKeysPostResponses];
+
+export type DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteData = {
   body?: never;
   path: {
-    report_id: string;
+    api_key_id: string;
   };
-  query?: {
-    /**
-     * Whether to delete associated retriever and pipeline data
-     */
-    cascade_delete?: boolean;
-    project_id?: string | null;
-    organization_id?: string | null;
-  };
-  url: "/api/v1/reports/{report_id}";
+  query?: never;
+  url: "/api/v1/beta/api-keys/{api_key_id}";
 };
 
-export type DeleteReportApiV1ReportsReportIdDeleteErrors = {
+export type DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteErrors = {
   /**
    * Validation Error
    */
   422: HttpValidationError;
 };
 
-export type DeleteReportApiV1ReportsReportIdDeleteError =
-  DeleteReportApiV1ReportsReportIdDeleteErrors[keyof DeleteReportApiV1ReportsReportIdDeleteErrors];
+export type DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteError =
+  DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteErrors[keyof DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteErrors];
 
-export type DeleteReportApiV1ReportsReportIdDeleteResponses = {
+export type DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteResponses = {
   /**
    * Successful Response
    */
-  200: unknown;
+  204: void;
 };
 
-export type GetReportApiV1ReportsReportIdGetData = {
+export type DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteResponse =
+  DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteResponses[keyof DeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteResponses];
+
+export type GetApiKeyApiV1BetaApiKeysApiKeyIdGetData = {
   body?: never;
   path: {
-    report_id: string;
+    api_key_id: string;
   };
-  query?: {
-    version?: number | null;
-    project_id?: string | null;
-    organization_id?: string | null;
-  };
-  url: "/api/v1/reports/{report_id}";
+  query?: never;
+  url: "/api/v1/beta/api-keys/{api_key_id}";
 };
 
-export type GetReportApiV1ReportsReportIdGetErrors = {
+export type GetApiKeyApiV1BetaApiKeysApiKeyIdGetErrors = {
   /**
    * Validation Error
    */
   422: HttpValidationError;
 };
 
-export type GetReportApiV1ReportsReportIdGetError =
-  GetReportApiV1ReportsReportIdGetErrors[keyof GetReportApiV1ReportsReportIdGetErrors];
+export type GetApiKeyApiV1BetaApiKeysApiKeyIdGetError =
+  GetApiKeyApiV1BetaApiKeysApiKeyIdGetErrors[keyof GetApiKeyApiV1BetaApiKeysApiKeyIdGetErrors];
 
-export type GetReportApiV1ReportsReportIdGetResponses = {
+export type GetApiKeyApiV1BetaApiKeysApiKeyIdGetResponses = {
   /**
    * Successful Response
    */
-  200: ReportResponse;
+  200: ApiKey;
 };
 
-export type GetReportApiV1ReportsReportIdGetResponse =
-  GetReportApiV1ReportsReportIdGetResponses[keyof GetReportApiV1ReportsReportIdGetResponses];
-
-export type UpdateReportApiV1ReportsReportIdPatchData = {
-  body: ReportVersionPatch;
-  path: {
-    report_id: string;
-  };
-  query?: {
-    project_id?: string | null;
-    organization_id?: string | null;
-  };
-  url: "/api/v1/reports/{report_id}";
-};
-
-export type UpdateReportApiV1ReportsReportIdPatchErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type UpdateReportApiV1ReportsReportIdPatchError =
-  UpdateReportApiV1ReportsReportIdPatchErrors[keyof UpdateReportApiV1ReportsReportIdPatchErrors];
-
-export type UpdateReportApiV1ReportsReportIdPatchResponses = {
-  /**
-   * Successful Response
-   */
-  200: ReportResponse;
-};
-
-export type UpdateReportApiV1ReportsReportIdPatchResponse =
-  UpdateReportApiV1ReportsReportIdPatchResponses[keyof UpdateReportApiV1ReportsReportIdPatchResponses];
-
-export type UpdateReportMetadataApiV1ReportsReportIdPostData = {
-  body: ReportNameUpdate;
-  path: {
-    report_id: string;
-  };
-  query?: {
-    project_id?: string | null;
-    organization_id?: string | null;
-  };
-  url: "/api/v1/reports/{report_id}";
-};
-
-export type UpdateReportMetadataApiV1ReportsReportIdPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type UpdateReportMetadataApiV1ReportsReportIdPostError =
-  UpdateReportMetadataApiV1ReportsReportIdPostErrors[keyof UpdateReportMetadataApiV1ReportsReportIdPostErrors];
-
-export type UpdateReportMetadataApiV1ReportsReportIdPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: ReportMetadata;
-};
-
-export type UpdateReportMetadataApiV1ReportsReportIdPostResponse =
-  UpdateReportMetadataApiV1ReportsReportIdPostResponses[keyof UpdateReportMetadataApiV1ReportsReportIdPostResponses];
-
-export type GetReportPlanApiV1ReportsReportIdPlanGetData = {
-  body?: never;
-  path: {
-    report_id: string;
-  };
-  query?: {
-    project_id?: string | null;
-    organization_id?: string | null;
-  };
-  url: "/api/v1/reports/{report_id}/plan";
-};
-
-export type GetReportPlanApiV1ReportsReportIdPlanGetErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type GetReportPlanApiV1ReportsReportIdPlanGetError =
-  GetReportPlanApiV1ReportsReportIdPlanGetErrors[keyof GetReportPlanApiV1ReportsReportIdPlanGetErrors];
-
-export type GetReportPlanApiV1ReportsReportIdPlanGetResponses = {
-  /**
-   * Successful Response
-   */
-  200: ReportPlan;
-};
-
-export type GetReportPlanApiV1ReportsReportIdPlanGetResponse =
-  GetReportPlanApiV1ReportsReportIdPlanGetResponses[keyof GetReportPlanApiV1ReportsReportIdPlanGetResponses];
-
-export type UpdateReportPlanApiV1ReportsReportIdPlanPatchData = {
-  body?: ReportPlan | null;
-  path: {
-    report_id: string;
-  };
-  query: {
-    action: "approve" | "reject" | "edit";
-    project_id?: string | null;
-    organization_id?: string | null;
-  };
-  url: "/api/v1/reports/{report_id}/plan";
-};
-
-export type UpdateReportPlanApiV1ReportsReportIdPlanPatchErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type UpdateReportPlanApiV1ReportsReportIdPlanPatchError =
-  UpdateReportPlanApiV1ReportsReportIdPlanPatchErrors[keyof UpdateReportPlanApiV1ReportsReportIdPlanPatchErrors];
-
-export type UpdateReportPlanApiV1ReportsReportIdPlanPatchResponses = {
-  /**
-   * Successful Response
-   */
-  200: ReportResponse;
-};
-
-export type UpdateReportPlanApiV1ReportsReportIdPlanPatchResponse =
-  UpdateReportPlanApiV1ReportsReportIdPlanPatchResponses[keyof UpdateReportPlanApiV1ReportsReportIdPlanPatchResponses];
-
-export type GetReportEventsApiV1ReportsReportIdEventsGetData = {
-  body?: never;
-  path: {
-    report_id: string;
-  };
-  query?: {
-    after?: string | null;
-    project_id?: string | null;
-    organization_id?: string | null;
-  };
-  url: "/api/v1/reports/{report_id}/events";
-};
-
-export type GetReportEventsApiV1ReportsReportIdEventsGetErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type GetReportEventsApiV1ReportsReportIdEventsGetError =
-  GetReportEventsApiV1ReportsReportIdEventsGetErrors[keyof GetReportEventsApiV1ReportsReportIdEventsGetErrors];
-
-export type GetReportEventsApiV1ReportsReportIdEventsGetResponses = {
-  /**
-   * Successful Response
-   */
-  200: Array<ReportEventItem>;
-};
-
-export type GetReportEventsApiV1ReportsReportIdEventsGetResponse =
-  GetReportEventsApiV1ReportsReportIdEventsGetResponses[keyof GetReportEventsApiV1ReportsReportIdEventsGetResponses];
-
-export type GetReportMetadataApiV1ReportsReportIdMetadataGetData = {
-  body?: never;
-  path: {
-    report_id: string;
-  };
-  query?: {
-    project_id?: string | null;
-    organization_id?: string | null;
-  };
-  url: "/api/v1/reports/{report_id}/metadata";
-};
-
-export type GetReportMetadataApiV1ReportsReportIdMetadataGetErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type GetReportMetadataApiV1ReportsReportIdMetadataGetError =
-  GetReportMetadataApiV1ReportsReportIdMetadataGetErrors[keyof GetReportMetadataApiV1ReportsReportIdMetadataGetErrors];
-
-export type GetReportMetadataApiV1ReportsReportIdMetadataGetResponses = {
-  /**
-   * Successful Response
-   */
-  200: ReportMetadata;
-};
-
-export type GetReportMetadataApiV1ReportsReportIdMetadataGetResponse =
-  GetReportMetadataApiV1ReportsReportIdMetadataGetResponses[keyof GetReportMetadataApiV1ReportsReportIdMetadataGetResponses];
-
-export type SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostData = {
-  body: EditSuggestionCreate;
-  path: {
-    report_id: string;
-  };
-  query?: {
-    project_id?: string | null;
-    organization_id?: string | null;
-  };
-  url: "/api/v1/reports/{report_id}/suggest_edits";
-};
-
-export type SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostError =
-  SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostErrors[keyof SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostErrors];
-
-export type SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: Array<EditSuggestion>;
-  };
-
-export type SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostResponse =
-  SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostResponses[keyof SuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostResponses];
-
-export type RestartReportApiV1ReportsReportIdRestartPostData = {
-  body?: never;
-  path: {
-    report_id: string;
-  };
-  query?: {
-    project_id?: string | null;
-    organization_id?: string | null;
-  };
-  url: "/api/v1/reports/{report_id}/restart";
-};
-
-export type RestartReportApiV1ReportsReportIdRestartPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type RestartReportApiV1ReportsReportIdRestartPostError =
-  RestartReportApiV1ReportsReportIdRestartPostErrors[keyof RestartReportApiV1ReportsReportIdRestartPostErrors];
-
-export type RestartReportApiV1ReportsReportIdRestartPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: unknown;
-};
+export type GetApiKeyApiV1BetaApiKeysApiKeyIdGetResponse =
+  GetApiKeyApiV1BetaApiKeysApiKeyIdGetResponses[keyof GetApiKeyApiV1BetaApiKeysApiKeyIdGetResponses];
 
 export type ListBatchesApiV1BetaBatchesGetData = {
   body?: never;
@@ -13976,7 +14690,10 @@ export type DeleteAgentDataApiV1BetaAgentDataItemIdDeleteData = {
   path: {
     item_id: string;
   };
-  query?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
   url: "/api/v1/beta/agent-data/{item_id}";
 };
 
@@ -14007,7 +14724,10 @@ export type GetAgentDataApiV1BetaAgentDataItemIdGetData = {
   path: {
     item_id: string;
   };
-  query?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
   url: "/api/v1/beta/agent-data/{item_id}";
 };
 
@@ -14036,7 +14756,10 @@ export type UpdateAgentDataApiV1BetaAgentDataItemIdPutData = {
   path: {
     item_id: string;
   };
-  query?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
   url: "/api/v1/beta/agent-data/{item_id}";
 };
 
@@ -14063,7 +14786,10 @@ export type UpdateAgentDataApiV1BetaAgentDataItemIdPutResponse =
 export type CreateAgentDataApiV1BetaAgentDataPostData = {
   body: AgentDataCreate;
   path?: never;
-  query?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
   url: "/api/v1/beta/agent-data";
 };
 
@@ -14090,7 +14816,10 @@ export type CreateAgentDataApiV1BetaAgentDataPostResponse =
 export type SearchAgentDataApiV1BetaAgentDataSearchPostData = {
   body: SearchRequest;
   path?: never;
-  query?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
   url: "/api/v1/beta/agent-data/:search";
 };
 
@@ -14117,7 +14846,10 @@ export type SearchAgentDataApiV1BetaAgentDataSearchPostResponse =
 export type AggregateAgentDataApiV1BetaAgentDataAggregatePostData = {
   body: AggregateRequest;
   path?: never;
-  query?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
   url: "/api/v1/beta/agent-data/:aggregate";
 };
 
@@ -14140,6 +14872,457 @@ export type AggregateAgentDataApiV1BetaAgentDataAggregatePostResponses = {
 
 export type AggregateAgentDataApiV1BetaAgentDataAggregatePostResponse =
   AggregateAgentDataApiV1BetaAgentDataAggregatePostResponses[keyof AggregateAgentDataApiV1BetaAgentDataAggregatePostResponses];
+
+export type ListQuotaConfigurationsApiV1BetaQuotaManagementGetData = {
+  body?: never;
+  path?: never;
+  query: {
+    source_type: "organization";
+    source_id: string;
+    page?: number;
+    page_size?: number;
+  };
+  url: "/api/v1/beta/quota-management";
+};
+
+export type ListQuotaConfigurationsApiV1BetaQuotaManagementGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type ListQuotaConfigurationsApiV1BetaQuotaManagementGetError =
+  ListQuotaConfigurationsApiV1BetaQuotaManagementGetErrors[keyof ListQuotaConfigurationsApiV1BetaQuotaManagementGetErrors];
+
+export type ListQuotaConfigurationsApiV1BetaQuotaManagementGetResponses = {
+  /**
+   * Successful Response
+   */
+  200: PaginatedResponseQuotaConfiguration;
+};
+
+export type ListQuotaConfigurationsApiV1BetaQuotaManagementGetResponse =
+  ListQuotaConfigurationsApiV1BetaQuotaManagementGetResponses[keyof ListQuotaConfigurationsApiV1BetaQuotaManagementGetResponses];
+
+export type CreateFileApiV1BetaFilesPostData = {
+  body: FileCreate;
+  path?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
+  url: "/api/v1/beta/files";
+};
+
+export type CreateFileApiV1BetaFilesPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CreateFileApiV1BetaFilesPostError =
+  CreateFileApiV1BetaFilesPostErrors[keyof CreateFileApiV1BetaFilesPostErrors];
+
+export type CreateFileApiV1BetaFilesPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: File;
+};
+
+export type CreateFileApiV1BetaFilesPostResponse =
+  CreateFileApiV1BetaFilesPostResponses[keyof CreateFileApiV1BetaFilesPostResponses];
+
+export type UpsertFileApiV1BetaFilesPutData = {
+  body: FileCreate;
+  path?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
+  url: "/api/v1/beta/files";
+};
+
+export type UpsertFileApiV1BetaFilesPutErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type UpsertFileApiV1BetaFilesPutError =
+  UpsertFileApiV1BetaFilesPutErrors[keyof UpsertFileApiV1BetaFilesPutErrors];
+
+export type UpsertFileApiV1BetaFilesPutResponses = {
+  /**
+   * Successful Response
+   */
+  200: File;
+};
+
+export type UpsertFileApiV1BetaFilesPutResponse =
+  UpsertFileApiV1BetaFilesPutResponses[keyof UpsertFileApiV1BetaFilesPutResponses];
+
+export type QueryFilesApiV1BetaFilesQueryPostData = {
+  body: FileQueryRequest;
+  path?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
+  url: "/api/v1/beta/files/query";
+};
+
+export type QueryFilesApiV1BetaFilesQueryPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type QueryFilesApiV1BetaFilesQueryPostError =
+  QueryFilesApiV1BetaFilesQueryPostErrors[keyof QueryFilesApiV1BetaFilesQueryPostErrors];
+
+export type QueryFilesApiV1BetaFilesQueryPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: FileQueryResponse;
+};
+
+export type QueryFilesApiV1BetaFilesQueryPostResponse =
+  QueryFilesApiV1BetaFilesQueryPostResponses[keyof QueryFilesApiV1BetaFilesQueryPostResponses];
+
+export type DeleteFileApiV1BetaFilesFileIdDeleteData = {
+  body?: never;
+  path: {
+    file_id: string;
+  };
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
+  url: "/api/v1/beta/files/{file_id}";
+};
+
+export type DeleteFileApiV1BetaFilesFileIdDeleteErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type DeleteFileApiV1BetaFilesFileIdDeleteError =
+  DeleteFileApiV1BetaFilesFileIdDeleteErrors[keyof DeleteFileApiV1BetaFilesFileIdDeleteErrors];
+
+export type DeleteFileApiV1BetaFilesFileIdDeleteResponses = {
+  /**
+   * Successful Response
+   */
+  204: void;
+};
+
+export type DeleteFileApiV1BetaFilesFileIdDeleteResponse =
+  DeleteFileApiV1BetaFilesFileIdDeleteResponses[keyof DeleteFileApiV1BetaFilesFileIdDeleteResponses];
+
+export type ListParseConfigurationsApiV1BetaParseConfigurationsGetData = {
+  body?: never;
+  path?: never;
+  query?: {
+    page_size?: number | null;
+    page_token?: string | null;
+    name?: string | null;
+    creator?: string | null;
+    version?: string | null;
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
+  url: "/api/v1/beta/parse-configurations";
+};
+
+export type ListParseConfigurationsApiV1BetaParseConfigurationsGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type ListParseConfigurationsApiV1BetaParseConfigurationsGetError =
+  ListParseConfigurationsApiV1BetaParseConfigurationsGetErrors[keyof ListParseConfigurationsApiV1BetaParseConfigurationsGetErrors];
+
+export type ListParseConfigurationsApiV1BetaParseConfigurationsGetResponses = {
+  /**
+   * Successful Response
+   */
+  200: ParseConfigurationQueryResponse;
+};
+
+export type ListParseConfigurationsApiV1BetaParseConfigurationsGetResponse =
+  ListParseConfigurationsApiV1BetaParseConfigurationsGetResponses[keyof ListParseConfigurationsApiV1BetaParseConfigurationsGetResponses];
+
+export type CreateParseConfigurationApiV1BetaParseConfigurationsPostData = {
+  body: ParseConfigurationCreate;
+  path?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
+  url: "/api/v1/beta/parse-configurations";
+};
+
+export type CreateParseConfigurationApiV1BetaParseConfigurationsPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CreateParseConfigurationApiV1BetaParseConfigurationsPostError =
+  CreateParseConfigurationApiV1BetaParseConfigurationsPostErrors[keyof CreateParseConfigurationApiV1BetaParseConfigurationsPostErrors];
+
+export type CreateParseConfigurationApiV1BetaParseConfigurationsPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    201: ParseConfiguration;
+  };
+
+export type CreateParseConfigurationApiV1BetaParseConfigurationsPostResponse =
+  CreateParseConfigurationApiV1BetaParseConfigurationsPostResponses[keyof CreateParseConfigurationApiV1BetaParseConfigurationsPostResponses];
+
+export type UpsertParseConfigurationApiV1BetaParseConfigurationsPutData = {
+  body: ParseConfigurationCreate;
+  path?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
+  url: "/api/v1/beta/parse-configurations";
+};
+
+export type UpsertParseConfigurationApiV1BetaParseConfigurationsPutErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type UpsertParseConfigurationApiV1BetaParseConfigurationsPutError =
+  UpsertParseConfigurationApiV1BetaParseConfigurationsPutErrors[keyof UpsertParseConfigurationApiV1BetaParseConfigurationsPutErrors];
+
+export type UpsertParseConfigurationApiV1BetaParseConfigurationsPutResponses = {
+  /**
+   * Successful Response
+   */
+  200: ParseConfiguration;
+};
+
+export type UpsertParseConfigurationApiV1BetaParseConfigurationsPutResponse =
+  UpsertParseConfigurationApiV1BetaParseConfigurationsPutResponses[keyof UpsertParseConfigurationApiV1BetaParseConfigurationsPutResponses];
+
+export type DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteData =
+  {
+    body?: never;
+    path: {
+      config_id: string;
+    };
+    query?: {
+      project_id?: string | null;
+      organization_id?: string | null;
+    };
+    url: "/api/v1/beta/parse-configurations/{config_id}";
+  };
+
+export type DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteError =
+  DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteErrors[keyof DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteErrors];
+
+export type DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteResponses =
+  {
+    /**
+     * Successful Response
+     */
+    204: void;
+  };
+
+export type DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteResponse =
+  DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteResponses[keyof DeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteResponses];
+
+export type GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetData = {
+  body?: never;
+  path: {
+    config_id: string;
+  };
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
+  url: "/api/v1/beta/parse-configurations/{config_id}";
+};
+
+export type GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetError =
+  GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetErrors[keyof GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetErrors];
+
+export type GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: ParseConfiguration;
+  };
+
+export type GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetResponse =
+  GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetResponses[keyof GetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetResponses];
+
+export type UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutData =
+  {
+    body: ParseConfigurationUpdate;
+    path: {
+      config_id: string;
+    };
+    query?: {
+      project_id?: string | null;
+      organization_id?: string | null;
+    };
+    url: "/api/v1/beta/parse-configurations/{config_id}";
+  };
+
+export type UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutError =
+  UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutErrors[keyof UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutErrors];
+
+export type UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: ParseConfiguration;
+  };
+
+export type UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutResponse =
+  UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutResponses[keyof UpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutResponses];
+
+export type QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostData =
+  {
+    body: ParseConfigurationQueryRequest;
+    path?: never;
+    query?: {
+      project_id?: string | null;
+      organization_id?: string | null;
+    };
+    url: "/api/v1/beta/parse-configurations/query";
+  };
+
+export type QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostError =
+  QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostErrors[keyof QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostErrors];
+
+export type QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: ParseConfigurationQueryResponse;
+  };
+
+export type QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostResponse =
+  QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostResponses[keyof QueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostResponses];
+
+export type GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetData =
+  {
+    body?: never;
+    path?: never;
+    query?: {
+      creator?: string | null;
+      project_id?: string | null;
+      organization_id?: string | null;
+    };
+    url: "/api/v1/beta/parse-configurations/latest";
+  };
+
+export type GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetError =
+  GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetErrors[keyof GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetErrors];
+
+export type GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: ParseConfiguration | null;
+  };
+
+export type GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetResponse =
+  GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetResponses[keyof GetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetResponses];
+
+export type UploadFileV2ApiV2Alpha1ParseUploadPostData = {
+  body: BodyUploadFileV2ApiV2Alpha1ParseUploadPost;
+  path?: never;
+  query?: {
+    project_id?: string | null;
+    organization_id?: string | null;
+  };
+  url: "/api/v2alpha1/parse/upload";
+};
+
+export type UploadFileV2ApiV2Alpha1ParseUploadPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type UploadFileV2ApiV2Alpha1ParseUploadPostError =
+  UploadFileV2ApiV2Alpha1ParseUploadPostErrors[keyof UploadFileV2ApiV2Alpha1ParseUploadPostErrors];
+
+export type UploadFileV2ApiV2Alpha1ParseUploadPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: ParsingJob;
+};
+
+export type UploadFileV2ApiV2Alpha1ParseUploadPostResponse =
+  UploadFileV2ApiV2Alpha1ParseUploadPostResponses[keyof UploadFileV2ApiV2Alpha1ParseUploadPostResponses];
 
 export type GetJobImageResultApiParsingJobJobIdResultImageNameGetData = {
   body?: never;

--- a/ts/llama_cloud_services/src/client/zod.gen.ts
+++ b/ts/llama_cloud_services/src/client/zod.gen.ts
@@ -2,12 +2,15 @@
 
 import { z } from "zod";
 
+export const zApiKeyType = z.enum(["user", "agent"]);
+
 export const zApiKey = z.object({
   id: z.string().uuid(),
   created_at: z.union([z.string().datetime(), z.null()]).optional(),
   updated_at: z.union([z.string().datetime(), z.null()]).optional(),
   name: z.union([z.string().min(0).max(3000), z.null()]).optional(),
   project_id: z.union([z.string().uuid(), z.null()]).optional(),
+  key_type: zApiKeyType.optional(),
   user_id: z.string(),
   redacted_api_key: z.string(),
 });
@@ -15,10 +18,13 @@ export const zApiKey = z.object({
 export const zApiKeyCreate = z.object({
   name: z.union([z.string().min(0).max(3000), z.null()]).optional(),
   project_id: z.union([z.string().uuid(), z.null()]).optional(),
+  key_type: zApiKeyType.optional(),
 });
 
-export const zApiKeyUpdate = z.object({
-  name: z.union([z.string().min(0).max(3000), z.null()]).optional(),
+export const zApiKeyQueryResponse = z.object({
+  items: z.array(zApiKey),
+  next_page_token: z.union([z.string(), z.null()]).optional(),
+  total_size: z.union([z.number().int(), z.null()]).optional(),
 });
 
 export const zNoneSegmentationConfig = z.object({
@@ -115,9 +121,9 @@ export const zAgentDeploymentSummary = z.object({
   deployment_name: z.string(),
   thumbnail_url: z.union([z.string(), z.null()]).optional(),
   base_url: z.string(),
-  display_name: z.string(),
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
+  api_key_id: z.union([z.string().uuid(), z.null()]).optional(),
 });
 
 export const zAgentDeploymentList = z.object({
@@ -140,7 +146,7 @@ export const zAggregateRequest = z.object({
   group_by: z.union([z.array(z.string()), z.null()]).optional(),
   count: z.union([z.boolean(), z.null()]).optional(),
   first: z.union([z.boolean(), z.null()]).optional(),
-  offset: z.union([z.number().int().gte(0), z.null()]).optional(),
+  offset: z.union([z.number().int().gte(0).lte(1000), z.null()]).optional(),
 });
 
 export const zMessageRole = z.enum([
@@ -164,14 +170,6 @@ export const zInputMessage = z.object({
 
 export const zAppChatInputParams = z.object({
   messages: z.array(zInputMessage).optional(),
-});
-
-export const zAudioBlock = z.object({
-  block_type: z.literal("audio").optional().default("audio"),
-  audio: z.union([z.string(), z.null()]).optional(),
-  path: z.union([z.string(), z.null()]).optional(),
-  url: z.union([z.string().url().min(1), z.null()]).optional(),
-  format: z.union([z.string(), z.null()]).optional(),
 });
 
 export const zAutoTransformConfig = z.object({
@@ -286,6 +284,32 @@ export const zBasePlan = z.object({
   failure_count: z.number().int().optional().default(0),
 });
 
+export const zWebhookConfiguration = z.object({
+  webhook_url: z.union([z.string(), z.null()]).optional(),
+  webhook_headers: z.union([z.object({}), z.null()]).optional(),
+  webhook_events: z
+    .union([
+      z.array(
+        z.enum([
+          "extract.pending",
+          "extract.success",
+          "extract.error",
+          "extract.partial_success",
+          "extract.cancelled",
+          "parse.pending",
+          "parse.success",
+          "parse.error",
+          "parse.partial_success",
+          "parse.cancelled",
+          "unmapped_event",
+        ]),
+      ),
+      z.null(),
+    ])
+    .optional(),
+  webhook_output_format: z.union([z.string(), z.null()]).optional(),
+});
+
 export const zParserLanguages = z.enum([
   "af",
   "az",
@@ -393,6 +417,9 @@ export const zFailPageMode = z.enum([
 ]);
 
 export const zLlamaParseParameters = z.object({
+  webhook_configurations: z
+    .union([z.array(zWebhookConfiguration), z.null()])
+    .optional(),
   priority: z
     .union([z.enum(["low", "medium", "high", "critical"]), z.null()])
     .optional(),
@@ -416,12 +443,23 @@ export const zLlamaParseParameters = z.object({
   preserve_layout_alignment_across_pages: z
     .union([z.boolean(), z.null()])
     .optional(),
+  preserve_very_small_text: z.union([z.boolean(), z.null()]).optional(),
   gpt4o_mode: z.union([z.boolean(), z.null()]).optional(),
   gpt4o_api_key: z.union([z.string(), z.null()]).optional(),
   do_not_unroll_columns: z.union([z.boolean(), z.null()]).optional(),
   extract_layout: z.union([z.boolean(), z.null()]).optional(),
   high_res_ocr: z.union([z.boolean(), z.null()]).optional(),
   html_make_all_elements_visible: z.union([z.boolean(), z.null()]).optional(),
+  layout_aware: z.union([z.boolean(), z.null()]).optional(),
+  specialized_chart_parsing_agentic: z
+    .union([z.boolean(), z.null()])
+    .optional(),
+  specialized_chart_parsing_plus: z.union([z.boolean(), z.null()]).optional(),
+  specialized_chart_parsing_efficient: z
+    .union([z.boolean(), z.null()])
+    .optional(),
+  specialized_image_parsing: z.union([z.boolean(), z.null()]).optional(),
+  precise_bounding_box: z.union([z.boolean(), z.null()]).optional(),
   html_remove_navigation_elements: z.union([z.boolean(), z.null()]).optional(),
   html_remove_fixed_elements: z.union([z.boolean(), z.null()]).optional(),
   guess_xlsx_sheet_name: z.union([z.boolean(), z.null()]).optional(),
@@ -481,6 +519,10 @@ export const zLlamaParseParameters = z.object({
     .optional(),
   content_guideline_instruction: z.union([z.string(), z.null()]).optional(),
   spreadsheet_extract_sub_tables: z.union([z.boolean(), z.null()]).optional(),
+  spreadsheet_force_formula_computation: z
+    .union([z.boolean(), z.null()])
+    .optional(),
+  inline_images_in_markdown: z.union([z.boolean(), z.null()]).optional(),
   job_timeout_in_seconds: z.union([z.number(), z.null()]).optional(),
   job_timeout_extra_time_per_page_in_seconds: z
     .union([z.number(), z.null()])
@@ -637,25 +679,6 @@ export const zBedrockEmbeddingConfig = z.object({
   component: zBedrockEmbedding.optional(),
 });
 
-export const zBodyClassifyDocumentsApiV1ClassifierClassifyPost = z.object({
-  rules_json: z.string(),
-  files: z.union([z.array(z.string()), z.null()]).optional(),
-  file_ids: z.union([z.string(), z.null()]).optional(),
-  matching_threshold: z
-    .union([z.number().gte(0.1).lte(0.99), z.null()])
-    .optional(),
-  enable_metadata_heuristic: z.union([z.boolean(), z.null()]).optional(),
-});
-
-export const zBodyCreateReportApiV1ReportsPost = z.object({
-  name: z.string(),
-  template_text: z.string().optional(),
-  template_instructions: z.union([z.string(), z.null()]).optional(),
-  existing_retriever_id: z.union([z.string().uuid(), z.null()]).optional(),
-  files: z.array(z.string()),
-  template_file: z.union([z.string(), z.null()]).optional(),
-});
-
 export const zBodyImportPipelineMetadataApiV1PipelinesPipelineIdMetadataPut =
   z.object({
     upload_file: z.string(),
@@ -668,26 +691,6 @@ export const zBodyRunJobOnFileApiV1ExtractionJobsFilePost = z.object({
   config_override: z.union([z.string(), z.null()]).optional(),
 });
 
-export const zWebhookConfiguration = z.object({
-  webhook_url: z.union([z.string(), z.null()]).optional(),
-  webhook_headers: z.union([z.object({}), z.null()]).optional(),
-  webhook_events: z
-    .union([
-      z.array(
-        z.enum([
-          "extract.pending",
-          "extract.success",
-          "extract.error",
-          "extract.partial_success",
-          "extract.cancelled",
-          "unmapped_event",
-        ]),
-      ),
-      z.null(),
-    ])
-    .optional(),
-});
-
 export const zExtractTarget = z.enum(["PER_DOC", "PER_PAGE"]);
 
 export const zExtractMode = z.enum([
@@ -695,6 +698,43 @@ export const zExtractMode = z.enum([
   "BALANCED",
   "PREMIUM",
   "MULTIMODAL",
+]);
+
+export const zPublicModelName = z.enum([
+  "openai-gpt-4o",
+  "openai-gpt-4o-mini",
+  "openai-gpt-4-1",
+  "openai-gpt-4-1-mini",
+  "openai-gpt-4-1-nano",
+  "openai-gpt-5",
+  "openai-gpt-5-mini",
+  "openai-gpt-5-nano",
+  "openai-text-embedding-3-small",
+  "openai-text-embedding-3-large",
+  "openai-whisper-1",
+  "anthropic-sonnet-3.5",
+  "anthropic-sonnet-3.5-v2",
+  "anthropic-sonnet-3.7",
+  "anthropic-sonnet-4.0",
+  "gemini-2.5-flash",
+  "gemini-2.5-pro",
+  "gemini-2.0-flash",
+  "gemini-2.0-flash-lite",
+  "gemini-1.5-flash",
+  "gemini-1.5-pro",
+]);
+
+export const zExtractModels = z.enum([
+  "openai-gpt-4-1",
+  "openai-gpt-4-1-mini",
+  "openai-gpt-4-1-nano",
+  "openai-gpt-5",
+  "openai-gpt-5-mini",
+  "gemini-2.0-flash",
+  "gemini-2.5-flash",
+  "gemini-2.5-pro",
+  "openai-gpt-4o",
+  "openai-gpt-4o-mini",
 ]);
 
 export const zDocumentChunkMode = z.enum(["PAGE", "SECTION"]);
@@ -705,15 +745,23 @@ export const zExtractConfig = z.object({
     .optional(),
   extraction_target: zExtractTarget.optional(),
   extraction_mode: zExtractMode.optional(),
+  parse_model: z.union([zPublicModelName, z.null()]).optional(),
+  extract_model: z.union([zExtractModels, z.null()]).optional(),
   multimodal_fast_mode: z.boolean().optional().default(false),
   system_prompt: z.union([z.string(), z.null()]).optional(),
   use_reasoning: z.boolean().optional().default(false),
   cite_sources: z.boolean().optional().default(false),
+  confidence_scores: z.boolean().optional().default(false),
   chunk_mode: zDocumentChunkMode.optional(),
+  high_resolution_mode: z.boolean().optional().default(false),
   invalidate_cache: z.boolean().optional().default(false),
+  page_range: z.union([z.string(), z.null()]).optional(),
 });
 
 export const zExtractJobCreate = z.object({
+  priority: z
+    .union([z.enum(["low", "medium", "high", "critical"]), z.null()])
+    .optional(),
   webhook_configurations: z
     .union([z.array(zWebhookConfiguration), z.null()])
     .optional(),
@@ -732,6 +780,8 @@ export const zChunkMode = z.enum([
   "GROUPED_PAGES",
 ]);
 
+export const zMultimodalParseResolution = z.enum(["medium", "high"]);
+
 export const zLlamaExtractSettings = z.object({
   max_file_size: z.number().int().optional().default(104857600),
   max_file_size_ui: z.number().int().optional().default(31457280),
@@ -742,6 +792,7 @@ export const zLlamaExtractSettings = z.object({
   use_multimodal_parsing: z.boolean().optional().default(false),
   use_pixel_extraction: z.boolean().optional().default(false),
   llama_parse_params: zLlamaParseParameters.optional(),
+  multimodal_parse_resolution: zMultimodalParseResolution.optional(),
 });
 
 export const zBodyRunJobTestUserApiV1ExtractionJobsTestPost = z.object({
@@ -762,6 +813,7 @@ export const zBodyScreenshotApiParsingScreenshotPost = z.object({
   output_s3_region: z.string().optional().default(""),
   target_pages: z.string().optional().default(""),
   webhook_url: z.string().optional().default(""),
+  webhook_configurations: z.string().optional().default(""),
   job_timeout_in_seconds: z.number().optional(),
   job_timeout_extra_time_per_page_in_seconds: z.number().optional(),
 });
@@ -779,6 +831,7 @@ export const zBodyScreenshotApiV1ParsingScreenshotPost = z.object({
   output_s3_region: z.string().optional().default(""),
   target_pages: z.string().optional().default(""),
   webhook_url: z.string().optional().default(""),
+  webhook_configurations: z.string().optional().default(""),
   job_timeout_in_seconds: z.number().optional(),
   job_timeout_extra_time_per_page_in_seconds: z.number().optional(),
 });
@@ -811,6 +864,12 @@ export const zBodyUploadFileApiParsingUploadPost = z.object({
   guess_xlsx_sheet_name: z.boolean().optional().default(false),
   high_res_ocr: z.boolean().optional().default(false),
   html_make_all_elements_visible: z.boolean().optional().default(false),
+  layout_aware: z.boolean().optional().default(false),
+  specialized_chart_parsing_agentic: z.boolean().optional().default(false),
+  specialized_chart_parsing_plus: z.boolean().optional().default(false),
+  specialized_chart_parsing_efficient: z.boolean().optional().default(false),
+  specialized_image_parsing: z.boolean().optional().default(false),
+  precise_bounding_box: z.boolean().optional().default(false),
   html_remove_fixed_elements: z.boolean().optional().default(false),
   html_remove_navigation_elements: z.boolean().optional().default(false),
   http_proxy: z.string().optional(),
@@ -830,8 +889,11 @@ export const zBodyUploadFileApiParsingUploadPost = z.object({
   page_separator: z.string().optional(),
   page_suffix: z.string().optional().default(""),
   preserve_layout_alignment_across_pages: z.boolean().optional().default(false),
+  preserve_very_small_text: z.boolean().optional().default(false),
   skip_diagonal_text: z.boolean().optional().default(false),
   spreadsheet_extract_sub_tables: z.boolean().optional().default(true),
+  spreadsheet_force_formula_computation: z.boolean().optional().default(false),
+  inline_images_in_markdown: z.boolean().optional().default(false),
   structured_output: z.boolean().optional().default(false),
   structured_output_json_schema: z.string().optional(),
   structured_output_json_schema_name: z.string().optional(),
@@ -841,6 +903,7 @@ export const zBodyUploadFileApiParsingUploadPost = z.object({
   vendor_multimodal_model_name: z.string().optional(),
   model: z.string().optional(),
   webhook_url: z.string().optional().default(""),
+  webhook_configurations: z.string().optional().default(""),
   preset: z.string().optional().default(""),
   parse_mode: z.union([zParsingMode, z.null()]).optional(),
   page_error_tolerance: z.number().optional().default(0.05),
@@ -921,6 +984,12 @@ export const zBodyUploadFileApiV1ParsingUploadPost = z.object({
   guess_xlsx_sheet_name: z.boolean().optional().default(false),
   high_res_ocr: z.boolean().optional().default(false),
   html_make_all_elements_visible: z.boolean().optional().default(false),
+  layout_aware: z.boolean().optional().default(false),
+  specialized_chart_parsing_agentic: z.boolean().optional().default(false),
+  specialized_chart_parsing_plus: z.boolean().optional().default(false),
+  specialized_chart_parsing_efficient: z.boolean().optional().default(false),
+  specialized_image_parsing: z.boolean().optional().default(false),
+  precise_bounding_box: z.boolean().optional().default(false),
   html_remove_fixed_elements: z.boolean().optional().default(false),
   html_remove_navigation_elements: z.boolean().optional().default(false),
   http_proxy: z.string().optional(),
@@ -940,8 +1009,11 @@ export const zBodyUploadFileApiV1ParsingUploadPost = z.object({
   page_separator: z.string().optional(),
   page_suffix: z.string().optional().default(""),
   preserve_layout_alignment_across_pages: z.boolean().optional().default(false),
+  preserve_very_small_text: z.boolean().optional().default(false),
   skip_diagonal_text: z.boolean().optional().default(false),
   spreadsheet_extract_sub_tables: z.boolean().optional().default(true),
+  spreadsheet_force_formula_computation: z.boolean().optional().default(false),
+  inline_images_in_markdown: z.boolean().optional().default(false),
   structured_output: z.boolean().optional().default(false),
   structured_output_json_schema: z.string().optional(),
   structured_output_json_schema_name: z.string().optional(),
@@ -951,6 +1023,7 @@ export const zBodyUploadFileApiV1ParsingUploadPost = z.object({
   vendor_multimodal_model_name: z.string().optional(),
   model: z.string().optional(),
   webhook_url: z.string().optional().default(""),
+  webhook_configurations: z.string().optional().default(""),
   preset: z.string().optional().default(""),
   parse_mode: z.union([zParsingMode, z.null()]).optional(),
   page_error_tolerance: z.number().optional().default(0.05),
@@ -999,6 +1072,11 @@ export const zBodyUploadFileApiV1ParsingUploadPost = z.object({
   page_footer_suffix: z.string().optional(),
 });
 
+export const zBodyUploadFileV2ApiV2Alpha1ParseUploadPost = z.object({
+  configuration: z.string(),
+  file: z.union([z.string(), z.null()]).optional(),
+});
+
 export const zBoxAuthMechanism = z.enum(["developer_token", "ccg"]);
 
 export const zSupportedLlmModelNames = z.enum([
@@ -1009,6 +1087,9 @@ export const zSupportedLlmModelNames = z.enum([
   "GPT_4_1_MINI",
   "AZURE_OPENAI_GPT_4O",
   "AZURE_OPENAI_GPT_4O_MINI",
+  "AZURE_OPENAI_GPT_4_1",
+  "AZURE_OPENAI_GPT_4_1_MINI",
+  "AZURE_OPENAI_GPT_4_1_NANO",
   "CLAUDE_3_5_SONNET",
   "BEDROCK_CLAUDE_3_5_SONNET_V1",
   "BEDROCK_CLAUDE_3_5_SONNET_V2",
@@ -1166,18 +1247,89 @@ export const zChatInputParams = z.object({
   class_name: z.string().optional().default("base_component"),
 });
 
-export const zClassificationResult = z.object({
-  file_id: z.string().uuid(),
+export const zMessageAnnotation = z.object({
   type: z.string(),
-  confidence: z.number().gte(0).lte(1),
-  matched_rule: z.union([z.string(), z.null()]),
+  data: z.string(),
+  class_name: z.string().optional().default("base_component"),
 });
 
-export const zClassifyResponse = z.object({
-  items: z.array(zClassificationResult),
+export const zChatMessage = z.object({
+  id: z.string().uuid(),
+  index: z.number().int(),
+  annotations: z.array(zMessageAnnotation).optional(),
+  role: zMessageRole,
+  content: z.union([z.string(), z.null()]).optional(),
+  additional_kwargs: z.object({}).optional(),
+  class_name: z.string().optional().default("base_component"),
+});
+
+export const zClassificationResult = z.object({
+  reasoning: z.string(),
+  confidence: z.number().gte(0).lte(1),
+  type: z.union([z.string(), z.null()]),
+});
+
+export const zClassifierRule = z.object({
+  type: z.string().min(1).max(50),
+  description: z.string().min(10).max(500),
+});
+
+export const zStatusEnum = z.enum([
+  "PENDING",
+  "SUCCESS",
+  "ERROR",
+  "PARTIAL_SUCCESS",
+  "CANCELLED",
+]);
+
+export const zClassifyParsingConfiguration = z.object({
+  lang: zParserLanguages.optional(),
+  max_pages: z.union([z.number().int(), z.null()]).optional(),
+  target_pages: z
+    .union([z.array(z.number().int()).min(1), z.null()])
+    .optional(),
+});
+
+export const zClassifyJob = z.object({
+  id: z.string().uuid(),
+  created_at: z.union([z.string().datetime(), z.null()]).optional(),
+  updated_at: z.union([z.string().datetime(), z.null()]).optional(),
+  rules: z.array(zClassifierRule).min(1),
+  user_id: z.string(),
+  project_id: z.string().uuid(),
+  status: zStatusEnum,
+  parsing_configuration: zClassifyParsingConfiguration.optional(),
+});
+
+export const zClassifyJobCreate = z.object({
+  rules: z.array(zClassifierRule).min(1),
+  file_ids: z.array(z.string().uuid()).min(1).max(500),
+  parsing_configuration: zClassifyParsingConfiguration.optional(),
+});
+
+export const zFileClassification = z.object({
+  id: z.string().uuid(),
+  created_at: z.union([z.string().datetime(), z.null()]).optional(),
+  updated_at: z.union([z.string().datetime(), z.null()]).optional(),
+  classify_job_id: z.string().uuid(),
+  file_id: z.string().uuid(),
+  result: z.union([zClassificationResult, z.null()]).optional(),
+});
+
+export const zClassifyJobResults = z.object({
+  items: z.array(zFileClassification),
   next_page_token: z.union([z.string(), z.null()]).optional(),
   total_size: z.union([z.number().int(), z.null()]).optional(),
-  unknown_count: z.number().int().gte(0),
+});
+
+export const zCloudAstraDbVectorStore = z.object({
+  supports_nested_metadata_filters: z.literal(true).optional().default(true),
+  token: z.string(),
+  api_endpoint: z.string(),
+  collection_name: z.string(),
+  embedding_dimension: z.number().int(),
+  keyspace: z.union([z.string(), z.null()]).optional(),
+  class_name: z.string().optional().default("CloudAstraDBVectorStore"),
 });
 
 export const zCloudAzStorageBlobDataSource = z.object({
@@ -1220,6 +1372,10 @@ export const zCloudBoxDataSource = z.object({
   class_name: z.string().optional().default("CloudBoxDataSource"),
 });
 
+export const zFailureHandlingConfig = z.object({
+  skip_list_failures: z.boolean().optional().default(false),
+});
+
 export const zCloudConfluenceDataSource = z.object({
   supports_access_control: z.boolean().optional().default(false),
   server_url: z.string(),
@@ -1231,7 +1387,8 @@ export const zCloudConfluenceDataSource = z.object({
   cql: z.union([z.string(), z.null()]).optional(),
   label: z.union([z.string(), z.null()]).optional(),
   index_restricted_pages: z.boolean().optional().default(false),
-  keep_markdown_format: z.boolean().optional().default(true),
+  keep_markdown_format: z.boolean().optional(),
+  failure_handling: zFailureHandlingConfig.optional(),
   class_name: z.string().optional().default("CloudConfluenceDataSource"),
 });
 
@@ -1262,6 +1419,22 @@ export const zCloudJiraDataSource = z.object({
   authentication_mechanism: z.string(),
   query: z.string(),
   class_name: z.string().optional().default("CloudJiraDataSource"),
+});
+
+export const zCloudJiraDataSourceV2 = z.object({
+  supports_access_control: z.boolean().optional().default(false),
+  email: z.union([z.string(), z.null()]).optional(),
+  api_token: z.union([z.string(), z.null()]).optional(),
+  server_url: z.string(),
+  cloud_id: z.union([z.string(), z.null()]).optional(),
+  authentication_mechanism: z.string(),
+  api_version: z.enum(["2", "3"]).optional(),
+  query: z.string(),
+  fields: z.union([z.array(z.string()), z.null()]).optional(),
+  expand: z.union([z.string(), z.null()]).optional(),
+  requests_per_minute: z.union([z.number().int(), z.null()]).optional(),
+  get_permissions: z.boolean().optional().default(true),
+  class_name: z.string().optional().default("CloudJiraDataSourceV2"),
 });
 
 export const zCloudMilvusVectorStore = z.object({
@@ -1486,6 +1659,7 @@ export const zConfigurableDataSinkNames = z.enum([
   "AZUREAI_SEARCH",
   "MONGODB_ATLAS",
   "MILVUS",
+  "ASTRA_DB",
 ]);
 
 export const zConfigurableDataSourceNames = z.enum([
@@ -1498,12 +1672,34 @@ export const zConfigurableDataSourceNames = z.enum([
   "NOTION_PAGE",
   "CONFLUENCE",
   "JIRA",
+  "JIRA_V2",
   "BOX",
 ]);
 
 export const zCreateIntentAndCustomerSessionResponse = z.object({
   client_secret: z.string(),
   customer_session_client_secret: z.union([z.string(), z.null()]),
+});
+
+export const zCustomClaims = z.object({
+  allowed_org_creation: z.boolean().optional().default(false),
+  max_jobs_in_execution_per_job_type: z.number().int().optional().default(10),
+  max_document_ingestion_jobs_in_execution: z
+    .number()
+    .int()
+    .optional()
+    .default(2),
+  max_metadata_update_jobs_in_execution: z
+    .number()
+    .int()
+    .optional()
+    .default(10),
+  extraction_test_user: z.boolean().optional().default(false),
+  allowed_report: z.boolean().optional().default(false),
+  allowed_app: z.boolean().optional().default(false),
+  allowed_classify: z.boolean().optional().default(true),
+  api_datasource_access: z.boolean().optional().default(false),
+  allow_org_deletion: z.boolean().optional().default(false),
 });
 
 export const zCustomerPortalSessionCreatePayload = z.object({
@@ -1524,6 +1720,7 @@ export const zDataSink = z.object({
     zCloudAzureAiSearchVectorStore,
     zCloudMongoDbAtlasVectorSearch,
     zCloudMilvusVectorStore,
+    zCloudAstraDbVectorStore,
   ]),
   project_id: z.string().uuid(),
 });
@@ -1539,6 +1736,7 @@ export const zDataSinkCreate = z.object({
     zCloudAzureAiSearchVectorStore,
     zCloudMongoDbAtlasVectorSearch,
     zCloudMilvusVectorStore,
+    zCloudAstraDbVectorStore,
   ]),
 });
 
@@ -1554,13 +1752,14 @@ export const zDataSinkUpdate = z.object({
       zCloudAzureAiSearchVectorStore,
       zCloudMongoDbAtlasVectorSearch,
       zCloudMilvusVectorStore,
+      zCloudAstraDbVectorStore,
       z.null(),
     ])
     .optional(),
 });
 
 export const zDataSourceReaderVersionMetadata = z.object({
-  reader_version: z.union([z.string(), z.null()]).optional(),
+  reader_version: z.union([z.enum(["1.0", "2.0", "2.1"]), z.null()]).optional(),
 });
 
 export const zDataSource = z.object({
@@ -1580,6 +1779,7 @@ export const zDataSource = z.object({
     zCloudNotionPageDataSource,
     zCloudConfluenceDataSource,
     zCloudJiraDataSource,
+    zCloudJiraDataSourceV2,
     zCloudBoxDataSource,
   ]),
   version_metadata: z
@@ -1602,6 +1802,7 @@ export const zDataSourceCreate = z.object({
     zCloudNotionPageDataSource,
     zCloudConfluenceDataSource,
     zCloudJiraDataSource,
+    zCloudJiraDataSourceV2,
     zCloudBoxDataSource,
   ]),
 });
@@ -1621,6 +1822,7 @@ export const zDataSourceUpdate = z.object({
       zCloudNotionPageDataSource,
       zCloudConfluenceDataSource,
       zCloudJiraDataSource,
+      zCloudJiraDataSourceV2,
       zCloudBoxDataSource,
       z.null(),
     ])
@@ -1668,15 +1870,6 @@ export const zDirectRetrievalParams = z.object({
   pipelines: z.array(zRetrieverPipeline).optional(),
 });
 
-export const zDocumentBlock = z.object({
-  block_type: z.literal("document").optional().default("document"),
-  data: z.union([z.string(), z.null()]).optional(),
-  path: z.union([z.string(), z.null()]).optional(),
-  url: z.union([z.string(), z.null()]).optional(),
-  title: z.union([z.string(), z.null()]).optional(),
-  document_mimetype: z.union([z.string(), z.null()]).optional(),
-});
-
 export const zDocumentIngestionJobParams = z.object({
   custom_metadata: z.union([z.object({}), z.null()]).optional(),
   resource_info: z.union([z.object({}), z.null()]).optional(),
@@ -1690,89 +1883,6 @@ export const zDocumentIngestionJobParams = z.object({
   delete_info: z.union([zDeleteParams, z.null()]).optional(),
   is_new_file: z.boolean().optional().default(false),
   page_count: z.union([z.number().int(), z.null()]).optional(),
-});
-
-export const zTextNode = z.object({
-  id_: z.string().optional(),
-  embedding: z.union([z.array(z.number()), z.null()]).optional(),
-  extra_info: z.object({}).optional(),
-  excluded_embed_metadata_keys: z.array(z.string()).optional(),
-  excluded_llm_metadata_keys: z.array(z.string()).optional(),
-  relationships: z.object({}).optional(),
-  metadata_template: z.string().optional().default("{key}: {value}"),
-  metadata_seperator: z.string().optional().default(`
-`),
-  text: z.string().optional().default(""),
-  mimetype: z.string().optional().default("text/plain"),
-  start_char_idx: z.union([z.number().int(), z.null()]).optional(),
-  end_char_idx: z.union([z.number().int(), z.null()]).optional(),
-  text_template: z.string().optional().default(`{metadata_str}
-
-{content}`),
-  class_name: z.string().optional().default("TextNode"),
-});
-
-export const zTextNodeWithScore = z.object({
-  node: zTextNode,
-  score: z.union([z.number(), z.null()]).optional(),
-  class_name: z.string().optional().default("TextNodeWithScore"),
-});
-
-export const zReportBlock = z.object({
-  idx: z.number().int(),
-  template: z.string(),
-  requires_human_review: z.boolean().optional().default(false),
-  sources: z.array(zTextNodeWithScore).optional(),
-});
-
-export const zReportQuery = z.object({
-  field: z.string(),
-  prompt: z.string(),
-  context: z.string(),
-});
-
-export const zReportBlockDependency = z.enum([
-  "none",
-  "all",
-  "previous",
-  "next",
-]);
-
-export const zReportPlanBlock = z.object({
-  block: zReportBlock,
-  queries: z.array(zReportQuery).optional(),
-  dependency: zReportBlockDependency,
-});
-
-export const zEditSuggestion = z.object({
-  justification: z.string(),
-  blocks: z.array(z.unknown()),
-  removed_indices: z.array(z.number().int()).optional(),
-});
-
-export const zTextBlock = z.object({
-  block_type: z.literal("text").optional().default("text"),
-  text: z.string(),
-});
-
-export const zImageBlock = z.object({
-  block_type: z.literal("image").optional().default("image"),
-  image: z.union([z.string(), z.null()]).optional(),
-  path: z.union([z.string(), z.null()]).optional(),
-  url: z.union([z.string().url().min(1), z.null()]).optional(),
-  image_mimetype: z.union([z.string(), z.null()]).optional(),
-  detail: z.union([z.string(), z.null()]).optional(),
-});
-
-export const zLlamaIndexCoreBaseLlmsTypesChatMessage = z.object({
-  role: zMessageRole.optional(),
-  additional_kwargs: z.object({}).optional(),
-  blocks: z.array(z.unknown()).optional(),
-});
-
-export const zEditSuggestionCreate = z.object({
-  user_query: z.string(),
-  chat_history: z.array(zLlamaIndexCoreBaseLlmsTypesChatMessage),
 });
 
 export const zGeminiEmbedding = z.object({
@@ -2018,6 +2128,7 @@ export const zExtractAgent = z.object({
   project_id: z.string().uuid(),
   data_schema: z.object({}),
   config: zExtractConfig,
+  custom_configuration: z.union([z.literal("default"), z.null()]).optional(),
   created_at: z.union([z.string().datetime(), z.null()]).optional(),
   updated_at: z.union([z.string().datetime(), z.null()]).optional(),
 });
@@ -2033,20 +2144,12 @@ export const zExtractAgentUpdate = z.object({
   config: zExtractConfig,
 });
 
-export const zStatusEnum = z.enum([
-  "PENDING",
-  "SUCCESS",
-  "ERROR",
-  "PARTIAL_SUCCESS",
-  "CANCELLED",
-]);
-
 export const zFile = z.object({
   id: z.string().uuid(),
   created_at: z.union([z.string().datetime(), z.null()]).optional(),
   updated_at: z.union([z.string().datetime(), z.null()]).optional(),
   name: z.string().min(1).max(3000),
-  external_file_id: z.string(),
+  external_file_id: z.union([z.string(), z.null()]).optional(),
   file_size: z.union([z.number().int().gte(0), z.null()]).optional(),
   file_type: z.union([z.string().min(1).max(3000), z.null()]).optional(),
   project_id: z.string().uuid(),
@@ -2072,19 +2175,6 @@ export const zExtractJobCreateBatch = z.object({
     .optional(),
   config_override: z.union([zExtractConfig, z.null()]).optional(),
 });
-
-export const zExtractModels = z.enum([
-  "gpt-4.1",
-  "gpt-4.1-mini",
-  "gpt-4.1-nano",
-  "gemini-2.0-flash",
-  "o3-mini",
-  "gemini-2.5-flash",
-  "gemini-2.5-pro",
-  "gemini-2.5-flash-lite-preview-06-17",
-  "gpt-4o",
-  "gpt-4o-mini",
-]);
 
 export const zExtractResultset = z.object({
   run_id: z.string().uuid(),
@@ -2128,6 +2218,22 @@ export const zExtractSchemaValidateResponse = z.object({
   data_schema: z.object({}),
 });
 
+export const zFileData = z.object({
+  data: z.string(),
+  mime_type: z.string(),
+});
+
+export const zExtractStatelessRequest = z.object({
+  webhook_configurations: z
+    .union([z.array(zWebhookConfiguration), z.null()])
+    .optional(),
+  data_schema: z.union([z.object({}), z.string()]),
+  config: zExtractConfig,
+  file_id: z.union([z.string().uuid(), z.null()]).optional(),
+  text: z.union([z.string(), z.null()]).optional(),
+  file: z.union([zFileData, z.null()]).optional(),
+});
+
 export const zFileCountByStatusResponse = z.object({
   counts: z.object({}),
   total_count: z.number().int(),
@@ -2156,11 +2262,33 @@ export const zFileCreateFromUrl = z.object({
   resource_info: z.union([z.object({}), z.null()]).optional(),
 });
 
+export const zFileFilter = z.object({
+  project_id: z.union([z.string().uuid(), z.null()]).optional(),
+  file_ids: z.union([z.array(z.string().uuid()), z.null()]).optional(),
+  file_name: z.union([z.string(), z.null()]).optional(),
+  data_source_id: z.union([z.string().uuid(), z.null()]).optional(),
+  external_file_id: z.union([z.string(), z.null()]).optional(),
+  only_manually_uploaded: z.union([z.boolean(), z.null()]).optional(),
+});
+
 export const zFileIdPresignedUrl = z.object({
   url: z.string().url().min(1),
   expires_at: z.string().datetime(),
   form_fields: z.union([z.object({}), z.null()]).optional(),
   file_id: z.string().uuid(),
+});
+
+export const zFileQueryRequest = z.object({
+  page_size: z.union([z.number().int(), z.null()]).optional(),
+  page_token: z.union([z.string(), z.null()]).optional(),
+  filter: z.union([zFileFilter, z.null()]).optional(),
+  order_by: z.union([z.string(), z.null()]).optional(),
+});
+
+export const zFileQueryResponse = z.object({
+  items: z.array(zFile),
+  next_page_token: z.union([z.string(), z.null()]).optional(),
+  total_size: z.union([z.number().int(), z.null()]).optional(),
 });
 
 export const zFilterOperation = z.object({
@@ -2194,7 +2322,6 @@ export const zJobNames = z.enum([
   "load_files_job",
   "playground_job",
   "pipeline_managed_ingestion_job",
-  "data_source_managed_ingestion_job",
   "data_source_update_dispatcher_job",
   "pipeline_file_update_dispatcher_job",
   "pipeline_file_updater_job",
@@ -2210,6 +2337,9 @@ export const zJobNames = z.enum([
 ]);
 
 export const zParseJobConfig = z.object({
+  webhook_configurations: z
+    .union([z.array(zWebhookConfiguration), z.null()])
+    .optional(),
   priority: z
     .union([z.enum(["low", "medium", "high", "critical"]), z.null()])
     .optional(),
@@ -2235,12 +2365,23 @@ export const zParseJobConfig = z.object({
   preserve_layout_alignment_across_pages: z
     .union([z.boolean(), z.null()])
     .optional(),
+  preserve_very_small_text: z.union([z.boolean(), z.null()]).optional(),
   gpt4o_mode: z.union([z.boolean(), z.null()]).optional(),
   gpt4o_api_key: z.union([z.string(), z.null()]).optional(),
   do_not_unroll_columns: z.union([z.boolean(), z.null()]).optional(),
   extract_layout: z.union([z.boolean(), z.null()]).optional(),
   high_res_ocr: z.union([z.boolean(), z.null()]).optional(),
   html_make_all_elements_visible: z.union([z.boolean(), z.null()]).optional(),
+  layout_aware: z.union([z.boolean(), z.null()]).optional(),
+  specialized_chart_parsing_agentic: z
+    .union([z.boolean(), z.null()])
+    .optional(),
+  specialized_chart_parsing_plus: z.union([z.boolean(), z.null()]).optional(),
+  specialized_chart_parsing_efficient: z
+    .union([z.boolean(), z.null()])
+    .optional(),
+  specialized_image_parsing: z.union([z.boolean(), z.null()]).optional(),
+  precise_bounding_box: z.union([z.boolean(), z.null()]).optional(),
   html_remove_navigation_elements: z.union([z.boolean(), z.null()]).optional(),
   html_remove_fixed_elements: z.union([z.boolean(), z.null()]).optional(),
   guess_xlsx_sheet_name: z.union([z.boolean(), z.null()]).optional(),
@@ -2300,6 +2441,10 @@ export const zParseJobConfig = z.object({
     .optional(),
   content_guideline_instruction: z.union([z.string(), z.null()]).optional(),
   spreadsheet_extract_sub_tables: z.union([z.boolean(), z.null()]).optional(),
+  spreadsheet_force_formula_computation: z
+    .union([z.boolean(), z.null()])
+    .optional(),
+  inline_images_in_markdown: z.union([z.boolean(), z.null()]).optional(),
   job_timeout_in_seconds: z.union([z.number(), z.null()]).optional(),
   job_timeout_extra_time_per_page_in_seconds: z
     .union([z.number(), z.null()])
@@ -2365,6 +2510,7 @@ export const zLegacyParseJobConfig = z.object({
   fromLLamaCloud: z.boolean().optional().default(false),
   skipDiagonalText: z.boolean().optional().default(false),
   preserveLayoutAlignmentAcrossPages: z.boolean().optional().default(false),
+  preserveVerySmallText: z.boolean().optional().default(false),
   invalidateCache: z.boolean(),
   outputPDFOfDocument: z.union([z.boolean(), z.null()]).optional(),
   outlinedTableExtraction: z.union([z.boolean(), z.null()]).optional(),
@@ -2374,6 +2520,9 @@ export const zLegacyParseJobConfig = z.object({
   openAIAPIKey: z.string(),
   doNotUnrollColumns: z.boolean().optional().default(false),
   spreadSheetExtractSubTables: z.union([z.boolean(), z.null()]).optional(),
+  spreadSheetForceFormulaComputation: z
+    .union([z.boolean(), z.null()])
+    .optional(),
   extractLayout: z.union([z.boolean(), z.null()]).optional(),
   highResOcr: z.union([z.boolean(), z.null()]).optional(),
   htmlMakeAllElementsVisible: z.union([z.boolean(), z.null()]).optional(),
@@ -2679,10 +2828,22 @@ export const zLlamaParseSupportedFileExtensions = z.enum([
   ".tsv",
 ]);
 
-export const zMessageAnnotation = z.object({
-  type: z.string(),
-  data: z.string(),
-  class_name: z.string().optional().default("base_component"),
+export const zManagedOpenAiEmbedding = z.object({
+  model_name: z
+    .literal("openai-text-embedding-3-small")
+    .optional()
+    .default("openai-text-embedding-3-small"),
+  embed_batch_size: z.number().int().lte(2048).optional().default(10),
+  num_workers: z.union([z.number().int(), z.null()]).optional(),
+  class_name: z.string().optional().default("ManagedOpenAIEmbedding"),
+});
+
+export const zManagedOpenAiEmbeddingConfig = z.object({
+  type: z
+    .literal("MANAGED_OPENAI_EMBEDDING")
+    .optional()
+    .default("MANAGED_OPENAI_EMBEDDING"),
+  component: zManagedOpenAiEmbedding.optional(),
 });
 
 export const zMetronomeDashboardResponse = z.object({
@@ -2704,6 +2865,7 @@ export const zOrganization = z.object({
   name: z.string().min(1).max(3000),
   stripe_customer_id: z.union([z.string(), z.null()]).optional(),
   parse_plan_level: zParsePlanLevel.optional(),
+  feature_flags: z.union([z.object({}), z.null()]).optional(),
 });
 
 export const zOrganizationCreate = z.object({
@@ -2712,6 +2874,7 @@ export const zOrganizationCreate = z.object({
 
 export const zOrganizationUpdate = z.object({
   name: z.string().min(1).max(3000),
+  feature_flags: z.union([z.object({}), z.null()]).optional(),
 });
 
 export const zPaginatedExtractRunsResponse = z.object({
@@ -2743,14 +2906,14 @@ export const zPipelineFile = z.object({
   external_file_id: z.union([z.string(), z.null()]).optional(),
   file_size: z.union([z.number().int().gte(0), z.null()]).optional(),
   file_type: z.union([z.string().min(1).max(3000), z.null()]).optional(),
-  project_id: z.string().uuid(),
+  project_id: z.union([z.string().uuid(), z.null()]).optional(),
   last_modified_at: z.union([z.string().datetime(), z.null()]).optional(),
-  resource_info: z.union([z.object({}), z.null()]).optional(),
-  permission_info: z.union([z.object({}), z.null()]).optional(),
-  data_source_id: z.union([z.string().uuid(), z.null()]).optional(),
   file_id: z.union([z.string().uuid(), z.null()]).optional(),
   pipeline_id: z.string().uuid(),
+  resource_info: z.union([z.object({}), z.null()]).optional(),
+  permission_info: z.union([z.object({}), z.null()]).optional(),
   custom_metadata: z.union([z.object({}), z.null()]).optional(),
+  data_source_id: z.union([z.string().uuid(), z.null()]).optional(),
   config_hash: z.union([z.object({}), z.null()]).optional(),
   indexed_page_count: z.union([z.number().int(), z.null()]).optional(),
   status: z
@@ -2769,44 +2932,6 @@ export const zPaginatedListPipelineFilesResponse = z.object({
   total_count: z.number().int(),
 });
 
-export const zReport = z.object({
-  id: z.string().uuid(),
-  blocks: z.array(zReportBlock).optional(),
-});
-
-export const zReportPlan = z.object({
-  id: z.string().uuid().optional(),
-  blocks: z.array(zReportPlanBlock).optional(),
-  generated_at: z.string().datetime().optional(),
-});
-
-export const zReportState = z.enum([
-  "pending",
-  "planning",
-  "waiting_approval",
-  "generating",
-  "completed",
-  "error",
-]);
-
-export const zReportResponse = z.object({
-  name: z.string(),
-  report_id: z.string().uuid(),
-  report: z.union([zReport, z.null()]),
-  plan: z.union([zReportPlan, z.null()]),
-  version: z.number().int(),
-  last_updated: z.string().datetime(),
-  status: zReportState,
-  total_versions: z.number().int(),
-});
-
-export const zPaginatedReportResponse = z.object({
-  report_responses: z.array(zReportResponse),
-  limit: z.number().int(),
-  offset: z.number().int(),
-  total_count: z.number().int(),
-});
-
 export const zPaginatedResponseAgentData = z.object({
   items: z.array(zAgentData),
   next_page_token: z.union([z.string(), z.null()]).optional(),
@@ -2817,6 +2942,96 @@ export const zPaginatedResponseAggregateGroup = z.object({
   items: z.array(zAggregateGroup),
   next_page_token: z.union([z.string(), z.null()]).optional(),
   total_size: z.union([z.number().int(), z.null()]).optional(),
+});
+
+export const zPaginatedResponseClassifyJob = z.object({
+  items: z.array(zClassifyJob),
+  next_page_token: z.union([z.string(), z.null()]).optional(),
+  total_size: z.union([z.number().int(), z.null()]).optional(),
+});
+
+export const zQuotaRateLimitConfigurationValue = z.object({
+  numerator: z.number().int(),
+  denominator: z.union([z.number().int(), z.null()]).optional(),
+  denominator_units: z
+    .union([z.enum(["second", "minute", "hour", "day"]), z.null()])
+    .optional(),
+});
+
+export const zQuotaConfiguration = z.object({
+  source_type: z.literal("organization"),
+  source_id: z.string(),
+  configuration_type: z.enum([
+    "rate_limit_parse_concurrent_premium",
+    "rate_limit_parse_concurrent_default",
+    "rate_limit_concurrent_jobs_in_execution_default",
+    "rate_limit_concurrent_jobs_in_execution_doc_ingest",
+    "limit_embedding_character",
+  ]),
+  configuration_value: zQuotaRateLimitConfigurationValue,
+  configuration_metadata: z.union([z.object({}), z.null()]),
+  started_at: z.string().datetime().optional(),
+  ended_at: z.union([z.string().datetime(), z.null()]).optional(),
+  idempotency_key: z.union([z.string(), z.null()]).optional(),
+  status: z.enum(["ACTIVE", "INACTIVE"]),
+  id: z.union([z.string().uuid(), z.null()]).optional(),
+  created_at: z.union([z.string().datetime(), z.null()]).optional(),
+  updated_at: z.union([z.string().datetime(), z.null()]).optional(),
+});
+
+export const zPaginatedResponseQuotaConfiguration = z.object({
+  total: z.number().int(),
+  page: z.number().int(),
+  size: z.number().int(),
+  pages: z.number().int(),
+  items: z.array(zQuotaConfiguration),
+});
+
+export const zParseConfiguration = z.object({
+  id: z.string(),
+  name: z.string(),
+  source_type: z.string(),
+  source_id: z.string(),
+  creator: z.union([z.string(), z.null()]).optional(),
+  version: z.string(),
+  parameters: zLlamaParseParameters,
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+});
+
+export const zParseConfigurationCreate = z.object({
+  name: z.string(),
+  source_type: z.union([z.string(), z.null()]).optional(),
+  source_id: z.union([z.string(), z.null()]).optional(),
+  creator: z.union([z.string(), z.null()]).optional(),
+  version: z.string(),
+  parameters: zLlamaParseParameters,
+});
+
+export const zParseConfigurationFilter = z.object({
+  name: z.union([z.string(), z.null()]).optional(),
+  source_type: z.union([z.string(), z.null()]).optional(),
+  source_id: z.union([z.string(), z.null()]).optional(),
+  creator: z.union([z.string(), z.null()]).optional(),
+  version: z.union([z.string(), z.null()]).optional(),
+  parse_config_ids: z.union([z.array(z.string()), z.null()]).optional(),
+});
+
+export const zParseConfigurationQueryRequest = z.object({
+  page_size: z.union([z.number().int(), z.null()]).optional(),
+  page_token: z.union([z.string(), z.null()]).optional(),
+  filter: z.union([zParseConfigurationFilter, z.null()]).optional(),
+  order_by: z.union([z.string(), z.null()]).optional(),
+});
+
+export const zParseConfigurationQueryResponse = z.object({
+  items: z.array(zParseConfiguration),
+  next_page_token: z.union([z.string(), z.null()]).optional(),
+  total_size: z.union([z.number().int(), z.null()]).optional(),
+});
+
+export const zParseConfigurationUpdate = z.object({
+  parameters: z.union([zLlamaParseParameters, z.null()]).optional(),
 });
 
 export const zParsingHistoryItem = z.object({
@@ -2879,6 +3094,13 @@ export const zPermission = z.object({
 
 export const zPipelineType = z.enum(["PLAYGROUND", "MANAGED"]);
 
+export const zSparseModelType = z.enum(["splade", "bm25", "auto"]);
+
+export const zSparseModelConfig = z.object({
+  model_type: zSparseModelType.optional(),
+  class_name: z.string().optional().default("SparseModelConfig"),
+});
+
 export const zPipelineConfigurationHashes = z.object({
   embedding_config_hash: z.union([z.string(), z.null()]).optional(),
   parsing_config_hash: z.union([z.string(), z.null()]).optional(),
@@ -2897,9 +3119,15 @@ export const zPipeline = z.object({
   name: z.string(),
   project_id: z.string().uuid(),
   embedding_model_config_id: z.union([z.string().uuid(), z.null()]).optional(),
+  embedding_model_config: z.union([zEmbeddingModelConfig, z.null()]).optional(),
   pipeline_type: zPipelineType.optional(),
   managed_pipeline_id: z.union([z.string().uuid(), z.null()]).optional(),
   embedding_config: z.union([
+    z
+      .object({
+        type: z.literal("MANAGED_OPENAI_EMBEDDING"),
+      })
+      .and(zManagedOpenAiEmbeddingConfig),
     z
       .object({
         type: z.literal("AZURE_EMBEDDING"),
@@ -2936,6 +3164,7 @@ export const zPipeline = z.object({
       })
       .and(zBedrockEmbeddingConfig),
   ]),
+  sparse_model_config: z.union([zSparseModelConfig, z.null()]).optional(),
   config_hash: z.union([zPipelineConfigurationHashes, z.null()]).optional(),
   transform_config: z
     .union([zAutoTransformConfig, zAdvancedModeTransformConfig])
@@ -2994,6 +3223,7 @@ export const zPipelineCreate = z.object({
   transform_config: z
     .union([zAutoTransformConfig, zAdvancedModeTransformConfig, z.null()])
     .optional(),
+  sparse_model_config: z.union([zSparseModelConfig, z.null()]).optional(),
   data_sink_id: z.union([z.string().uuid(), z.null()]).optional(),
   embedding_model_config_id: z.union([z.string().uuid(), z.null()]).optional(),
   data_sink: z.union([zDataSinkCreate, z.null()]).optional(),
@@ -3024,6 +3254,7 @@ export const zPipelineDataSource = z.object({
     zCloudNotionPageDataSource,
     zCloudConfluenceDataSource,
     zCloudJiraDataSource,
+    zCloudJiraDataSourceV2,
     zCloudBoxDataSource,
   ]),
   version_metadata: z
@@ -3117,6 +3348,7 @@ export const zPipelineUpdate = z.object({
   transform_config: z
     .union([zAutoTransformConfig, zAdvancedModeTransformConfig, z.null()])
     .optional(),
+  sparse_model_config: z.union([zSparseModelConfig, z.null()]).optional(),
   data_sink_id: z.union([z.string().uuid(), z.null()]).optional(),
   embedding_model_config_id: z.union([z.string().uuid(), z.null()]).optional(),
   data_sink: z.union([zDataSinkCreate, z.null()]).optional(),
@@ -3131,16 +3363,6 @@ export const zPipelineUpdate = z.object({
   managed_pipeline_id: z.union([z.string().uuid(), z.null()]).optional(),
 });
 
-export const zSrcAppSchemaChatChatMessage = z.object({
-  id: z.string().uuid(),
-  index: z.number().int(),
-  annotations: z.array(zMessageAnnotation).optional(),
-  role: zMessageRole,
-  content: z.union([z.string(), z.null()]).optional(),
-  additional_kwargs: z.object({}).optional(),
-  class_name: z.string().optional().default("base_component"),
-});
-
 export const zPlaygroundSession = z.object({
   id: z.string().uuid(),
   created_at: z.union([z.string().datetime(), z.null()]).optional(),
@@ -3151,34 +3373,13 @@ export const zPlaygroundSession = z.object({
   llm_params: zLlmParameters.optional(),
   retrieval_params_id: z.string().uuid(),
   retrieval_params: zPresetRetrievalParams.optional(),
-  chat_messages: z.array(zSrcAppSchemaChatChatMessage).optional(),
+  chat_messages: z.array(zChatMessage).optional(),
 });
 
 export const zPresignedUrl = z.object({
   url: z.string().url().min(1),
   expires_at: z.string().datetime(),
   form_fields: z.union([z.object({}), z.null()]).optional(),
-});
-
-export const zReportEventType = z.enum([
-  "load_template",
-  "extract_plan",
-  "summarize",
-  "file_processing",
-  "generate_block",
-  "editing",
-]);
-
-export const zProgressEvent = z.object({
-  timestamp: z.string().datetime().optional(),
-  id: z.string().uuid().optional(),
-  group_id: z.string().uuid().optional(),
-  type: z.literal("progress").optional().default("progress"),
-  variant: zReportEventType,
-  msg: z.string(),
-  progress: z.union([z.number().gte(0).lte(1), z.null()]).optional(),
-  status: z.enum(["pending", "in_progress", "completed", "error"]).optional(),
-  extra_detail: z.union([z.object({}), z.null()]).optional(),
 });
 
 export const zProject = z.object({
@@ -3219,7 +3420,7 @@ export const zPromptConf = z.object({
   reasoning_prompt: z.string().optional().default(`
 Provide a brief explanation for how you arrived at the extracted value based on the source text provided.
 - For inferred values, explain the reasoning behind the extraction briefly.
-- For simple verbatim extraction, output 'VERBATIM EXTRACTION'. 
+- For simple verbatim extraction, output 'VERBATIM EXTRACTION'.
 - When supporting data is not present in the source text, output 'INSUFFICIENT DATA' and emit blank or null values for the value__ field.
 `),
   cite_sources_prompt: z
@@ -3228,13 +3429,13 @@ Provide a brief explanation for how you arrived at the extracted value based on 
     .default({
       description: `
 ### Citation Rules (read carefully):
-- You must ANNOTATE every value with a short EXACT substring from the source text that supports it.
-- For inferred values, cite the text used to infer it or output 'INFERRED FROM TEXT'
+- You must ANNOTATE every value with the MOST RELEVANT short EXACT substring from the source text that supports it.
+- For inferred values, cite the text used to infer it in the matching_text field or output 'INFERRED FROM TEXT'
 - If no support exists, output 'INSUFFICIENT DATA' and leave value__ null or '', 0.0, False etc depending on the type of the field.
 `,
       page: "Cite the page number of the source text that the extracted value is from. The page number is the integer that appears right after <<<PAGE:. If no page number is present in this format, use the default value of 1.",
       matching_text:
-        'Cite the **EXACT TEXT from the SOURCE TEXT** that supports the extracted value within 120 characters. If the exact substring is >120 chars, truncate with ellipsis "...".',
+        'Cite the **MOST RELEVANT EXACT TEXT from the SOURCE TEXT** that supports the extracted value within 80 characters. If the exact substring is >80 chars, truncate with ellipsis "...". Provide only the single most relevant citation.',
     }),
   scratchpad_prompt: z
     .string()
@@ -3250,55 +3451,8 @@ export const zRelatedNodeInfo = z.object({
   class_name: z.string().optional().default("RelatedNodeInfo"),
 });
 
-export const zReportCreateResponse = z.object({
-  id: z.string().uuid(),
-});
-
-export const zReportUpdateEvent = z.object({
-  timestamp: z.string().datetime().optional(),
-  type: z
-    .literal("report_block_update")
-    .optional()
-    .default("report_block_update"),
-  msg: z
-    .string()
-    .optional()
-    .default("A block has been generated and is ready to be displayed"),
-  block: zReportBlock,
-});
-
-export const zReportStateEvent = z.object({
-  timestamp: z.string().datetime().optional(),
-  type: z.literal("report_state_update"),
-  msg: z.string(),
-  status: zReportState,
-});
-
-export const zReportEventItem = z.object({
-  id: z.string().uuid(),
-  report_id: z.string().uuid(),
-  event_type: z.string(),
-  event_data: z.union([zProgressEvent, zReportUpdateEvent, zReportStateEvent]),
-  timestamp: z.string().datetime(),
-});
-
-export const zReportMetadata = z.object({
-  id: z.string().uuid(),
-  name: z.string(),
-  report_metadata: z.object({}),
-  state: zReportState,
-  input_files: z.union([z.array(z.string()), z.null()]).optional(),
-  template_file: z.union([z.string(), z.null()]).optional(),
-  template_text: z.union([z.string(), z.null()]).optional(),
-  template_instructions: z.union([z.string(), z.null()]).optional(),
-});
-
-export const zReportNameUpdate = z.object({
-  name: z.string(),
-});
-
-export const zReportVersionPatch = z.object({
-  content: zReport,
+export const zRestrict = z.object({
+  project_id: z.union([z.string().uuid(), z.null()]),
 });
 
 export const zRetrievalParams = z.object({
@@ -3325,6 +3479,32 @@ export const zRetrievalParams = z.object({
   retrieve_page_figure_nodes: z.boolean().optional().default(false),
   query: z.string().min(1),
   class_name: z.string().optional().default("base_component"),
+});
+
+export const zTextNode = z.object({
+  id_: z.string().optional(),
+  embedding: z.union([z.array(z.number()), z.null()]).optional(),
+  extra_info: z.object({}).optional(),
+  excluded_embed_metadata_keys: z.array(z.string()).optional(),
+  excluded_llm_metadata_keys: z.array(z.string()).optional(),
+  relationships: z.object({}).optional(),
+  metadata_template: z.string().optional().default("{key}: {value}"),
+  metadata_seperator: z.string().optional().default(`
+`),
+  text: z.string().optional().default(""),
+  mimetype: z.string().optional().default("text/plain"),
+  start_char_idx: z.union([z.number().int(), z.null()]).optional(),
+  end_char_idx: z.union([z.number().int(), z.null()]).optional(),
+  text_template: z.string().optional().default(`{metadata_str}
+
+{content}`),
+  class_name: z.string().optional().default("TextNode"),
+});
+
+export const zTextNodeWithScore = z.object({
+  node: zTextNode,
+  score: z.union([z.number(), z.null()]).optional(),
+  class_name: z.string().optional().default("TextNodeWithScore"),
 });
 
 export const zRetrieveResults = z.object({
@@ -3375,7 +3555,7 @@ export const zSearchRequest = z.object({
   deployment_name: z.string(),
   collection: z.string().optional().default("default"),
   include_total: z.boolean().optional().default(false),
-  offset: z.union([z.number().int().gte(0), z.null()]).optional(),
+  offset: z.union([z.number().int().gte(0).lte(1000), z.null()]).optional(),
 });
 
 export const zStructMode = z.enum([
@@ -3391,6 +3571,7 @@ export const zStructParseConf = z.object({
   temperature: z.number().optional().default(0),
   relaxation_mode: zSchemaRelaxMode.optional(),
   struct_mode: zStructMode.optional(),
+  fetch_logprobs: z.boolean().optional().default(false),
   handle_missing: z.boolean().optional().default(false),
   use_reasoning: z.boolean().optional().default(false),
   cite_sources: z.boolean().optional().default(false),
@@ -3415,6 +3596,8 @@ export const zUsageResponse = z.object({
         "plan_spend_limit_soft_alert",
         "configured_spend_limit_exceeded",
         "free_credits_exhausted",
+        "internal_spending_alert",
+        "has_spending_alert",
       ]),
     )
     .optional()
@@ -3428,6 +3611,18 @@ export const zUsageResponse = z.object({
 export const zUsageAndPlan = z.object({
   plan: zBasePlan,
   usage: zUsageResponse,
+});
+
+export const zUser = z.object({
+  id: z.string(),
+  email: z.string().email(),
+  last_login_provider: z.enum(["oidc", "basic", "no_auth"]).optional(),
+  name: z.union([z.string(), z.null()]).optional(),
+  first_name: z.union([z.string(), z.null()]).optional(),
+  last_name: z.union([z.string(), z.null()]).optional(),
+  claims: zCustomClaims.optional(),
+  restrict: z.union([zRestrict, z.null()]).optional(),
+  created_at: z.union([z.string().datetime(), z.null()]).optional(),
 });
 
 export const zUserOrganizationRole = z.object({
@@ -3472,19 +3667,17 @@ export const zUserOrganizationRoleCreate = z.object({
   role_id: z.string().uuid(),
 });
 
-export const zStatelessExtractionRequest = z.object({
-  data_schema: z.union([z.object({}), z.string(), z.null()]),
-  config: zExtractConfig.optional(),
-  file_id: z.string().uuid().optional(),
-});
+export const zListDeploymentsApiV1ProjectsProjectIdAgentsGetResponse =
+  zAgentDeploymentList;
+
+export const zSyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponse =
+  zAgentDeploymentList;
 
 export const zListKeysApiV1ApiKeysGetResponse = z.array(zApiKey);
 
 export const zGenerateKeyApiV1ApiKeysPostResponse = zApiKey;
 
 export const zDeleteApiKeyApiV1ApiKeysApiKeyIdDeleteResponse = z.void();
-
-export const zUpdateExistingApiKeyApiV1ApiKeysApiKeyIdPutResponse = zApiKey;
 
 export const zValidateEmbeddingConnectionApiV1ValidateIntegrationsValidateEmbeddingConnectionPostResponse =
   zBaseConnectionValidation;
@@ -3627,6 +3820,12 @@ export const zListFilePagesFiguresApiV1FilesIdPageFiguresGetResponse =
 
 export const zListFilePageFiguresApiV1FilesIdPageFiguresPageIndexGetResponse =
   z.array(zPageFigureMetadata);
+
+export const zGenerateFilePageScreenshotPresignedUrlApiV1FilesIdPageScreenshotsPageIndexPresignedUrlPostResponse =
+  zPresignedUrl;
+
+export const zGenerateFilePageFigurePresignedUrlApiV1FilesIdPageFiguresPageIndexFigureNamePresignedUrlPostResponse =
+  zPresignedUrl;
 
 export const zSearchPipelinesApiV1PipelinesGetResponse = z.array(zPipeline);
 
@@ -3794,14 +3993,18 @@ export const zGetChatAppApiV1AppsIdGetResponse = zChatApp;
 
 export const zUpdateChatAppApiV1AppsIdPutResponse = zChatApp;
 
-export const zListDeploymentsApiV1ProjectsProjectIdAgentsGetResponse =
-  zAgentDeploymentList;
+export const zListClassifyJobsApiV1ClassifierJobsGetResponse =
+  zPaginatedResponseClassifyJob;
 
-export const zSyncDeploymentsApiV1ProjectsProjectIdAgentsSyncPostResponse =
-  zAgentDeploymentList;
+export const zCreateClassifyJobApiV1ClassifierJobsPostResponse = zClassifyJob;
 
-export const zClassifyDocumentsApiV1ClassifierClassifyPostResponse =
-  zClassifyResponse;
+export const zGetClassifyJobApiV1ClassifierJobsClassifyJobIdGetResponse =
+  zClassifyJob;
+
+export const zGetClassificationJobResultsApiV1ClassifierJobsClassifyJobIdResultsGetResponse =
+  zClassifyJobResults;
+
+export const zReadSelfApiV1AuthMeGetResponse = zUser;
 
 export const zCreateCustomerPortalSessionApiV1BillingCustomerPortalSessionPostResponse =
   z.string();
@@ -3829,13 +4032,14 @@ export const zGenerateExtractionSchemaApiV1ExtractionExtractionAgentsSchemaGener
 export const zGetExtractionAgentByNameApiV1ExtractionExtractionAgentsByNameNameGetResponse =
   zExtractAgent;
 
+export const zGetOrCreateDefaultExtractionAgentApiV1ExtractionExtractionAgentsDefaultGetResponse =
+  zExtractAgent;
+
 export const zGetExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentIdGetResponse =
   zExtractAgent;
 
 export const zUpdateExtractionAgentApiV1ExtractionExtractionAgentsExtractionAgentIdPutResponse =
   zExtractAgent;
-
-export const zExtractStatelessApiV1ExtractionRunPostResponse = zExtractJob;
 
 export const zListJobsApiV1ExtractionJobsGetResponse = z.array(zExtractJob);
 
@@ -3864,30 +4068,15 @@ export const zGetRunByJobIdApiV1ExtractionRunsByJobJobIdGetResponse =
 
 export const zGetRunApiV1ExtractionRunsRunIdGetResponse = zExtractRun;
 
-export const zCreateReportApiV1ReportsPostResponse = zReportCreateResponse;
+export const zExtractStatelessApiV1ExtractionRunPostResponse = zExtractJob;
 
-export const zListReportsApiV1ReportsListGetResponse = zPaginatedReportResponse;
+export const zListApiKeysApiV1BetaApiKeysGetResponse = zApiKeyQueryResponse;
 
-export const zGetReportApiV1ReportsReportIdGetResponse = zReportResponse;
+export const zCreateApiKeyApiV1BetaApiKeysPostResponse = zApiKey;
 
-export const zUpdateReportApiV1ReportsReportIdPatchResponse = zReportResponse;
+export const zDeleteApiKeyApiV1BetaApiKeysApiKeyIdDeleteResponse = z.void();
 
-export const zUpdateReportMetadataApiV1ReportsReportIdPostResponse =
-  zReportMetadata;
-
-export const zGetReportPlanApiV1ReportsReportIdPlanGetResponse = zReportPlan;
-
-export const zUpdateReportPlanApiV1ReportsReportIdPlanPatchResponse =
-  zReportResponse;
-
-export const zGetReportEventsApiV1ReportsReportIdEventsGetResponse =
-  z.array(zReportEventItem);
-
-export const zGetReportMetadataApiV1ReportsReportIdMetadataGetResponse =
-  zReportMetadata;
-
-export const zSuggestEditsEndpointApiV1ReportsReportIdSuggestEditsPostResponse =
-  z.array(zEditSuggestion);
+export const zGetApiKeyApiV1BetaApiKeysApiKeyIdGetResponse = zApiKey;
 
 export const zListBatchesApiV1BetaBatchesGetResponse = zBatchPaginatedList;
 
@@ -3910,6 +4099,43 @@ export const zSearchAgentDataApiV1BetaAgentDataSearchPostResponse =
 
 export const zAggregateAgentDataApiV1BetaAgentDataAggregatePostResponse =
   zPaginatedResponseAggregateGroup;
+
+export const zListQuotaConfigurationsApiV1BetaQuotaManagementGetResponse =
+  zPaginatedResponseQuotaConfiguration;
+
+export const zCreateFileApiV1BetaFilesPostResponse = zFile;
+
+export const zUpsertFileApiV1BetaFilesPutResponse = zFile;
+
+export const zQueryFilesApiV1BetaFilesQueryPostResponse = zFileQueryResponse;
+
+export const zDeleteFileApiV1BetaFilesFileIdDeleteResponse = z.void();
+
+export const zListParseConfigurationsApiV1BetaParseConfigurationsGetResponse =
+  zParseConfigurationQueryResponse;
+
+export const zCreateParseConfigurationApiV1BetaParseConfigurationsPostResponse =
+  zParseConfiguration;
+
+export const zUpsertParseConfigurationApiV1BetaParseConfigurationsPutResponse =
+  zParseConfiguration;
+
+export const zDeleteParseConfigurationApiV1BetaParseConfigurationsConfigIdDeleteResponse =
+  z.void();
+
+export const zGetParseConfigurationApiV1BetaParseConfigurationsConfigIdGetResponse =
+  zParseConfiguration;
+
+export const zUpdateParseConfigurationApiV1BetaParseConfigurationsConfigIdPutResponse =
+  zParseConfiguration;
+
+export const zQueryParseConfigurationsApiV1BetaParseConfigurationsQueryPostResponse =
+  zParseConfigurationQueryResponse;
+
+export const zGetLatestParseConfigurationApiV1BetaParseConfigurationsLatestGetResponse =
+  z.union([zParseConfiguration, z.null()]);
+
+export const zUploadFileV2ApiV2Alpha1ParseUploadPostResponse = zParsingJob;
 
 export const zGetSupportedFileExtensionsApiParsingSupportedFileExtensionsGetResponse =
   z.array(zLlamaParseSupportedFileExtensions);

--- a/ts/llama_cloud_services/src/client/zod.gen.ts
+++ b/ts/llama_cloud_services/src/client/zod.gen.ts
@@ -92,7 +92,7 @@ export const zAdvancedModeTransformConfig = z.object({
 
 export const zAgentData = z.object({
   id: z.union([z.string(), z.null()]).optional(),
-  agent_slug: z.string(),
+  deployment_name: z.string(),
   collection: z.string().optional().default("default"),
   data: z.object({}),
   created_at: z.union([z.string().datetime(), z.null()]).optional(),
@@ -100,7 +100,7 @@ export const zAgentData = z.object({
 });
 
 export const zAgentDataCreate = z.object({
-  agent_slug: z.string(),
+  deployment_name: z.string(),
   collection: z.string().optional().default("default"),
   data: z.object({}),
 });
@@ -112,7 +112,7 @@ export const zAgentDataUpdate = z.object({
 export const zAgentDeploymentSummary = z.object({
   id: z.string(),
   project_id: z.string().uuid(),
-  agent_slug: z.string(),
+  deployment_name: z.string(),
   thumbnail_url: z.union([z.string(), z.null()]).optional(),
   base_url: z.string(),
   display_name: z.string(),
@@ -135,7 +135,7 @@ export const zAggregateRequest = z.object({
   page_token: z.union([z.string(), z.null()]).optional(),
   filter: z.union([z.object({}), z.null()]).optional(),
   order_by: z.union([z.string(), z.null()]).optional(),
-  agent_slug: z.string(),
+  deployment_name: z.string(),
   collection: z.string().optional().default("default"),
   group_by: z.union([z.array(z.string()), z.null()]).optional(),
   count: z.union([z.boolean(), z.null()]).optional(),
@@ -3372,7 +3372,7 @@ export const zSearchRequest = z.object({
   page_token: z.union([z.string(), z.null()]).optional(),
   filter: z.union([z.object({}), z.null()]).optional(),
   order_by: z.union([z.string(), z.null()]).optional(),
-  agent_slug: z.string(),
+  deployment_name: z.string(),
   collection: z.string().optional().default("default"),
   include_total: z.boolean().optional().default(false),
   offset: z.union([z.number().int().gte(0), z.null()]).optional(),


### PR DESCRIPTION
Refactor `agent_slug`/`agentSlug`, and `agentUrlId`/`agentUrlId` to just `deployment_name`/`deploymentName` across Python and TypeScript SDKs.

This change aligns the SDKs with the updated platform API schema, which has removed `agent_slug` from its models.

This also regenerates the ts sdk, which turned out to be a lot of things. This process could still use some improvements

---
Linear Issue: [LI-3577](https://linear.app/llamaindex/issue/LI-3577/refactor-agent-slug-and-agenturlid-out-of-llama-cloud-services)

<a href="https://cursor.com/background-agent?bcId=bc-d8505ef3-ca32-433b-8985-b9e42fe99d4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8505ef3-ca32-433b-8985-b9e42fe99d4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

