### PR TITLE
Handle validation errors for agent data retrieval

### DIFF
--- a/py/llama_cloud_services/beta/agent_data/__init__.py
+++ b/py/llama_cloud_services/beta/agent_data/__init__.py
@@ -9,6 +9,7 @@ from .schema import (
     parse_extracted_field_metadata,
     calculate_overall_confidence,
     InvalidExtractionData,
+    InvalidTypedAgentData,
     ExtractedFieldMetadata,
     ExtractedFieldMetaDataDict,
 )
@@ -26,6 +27,7 @@ __all__ = [
     "parse_extracted_field_metadata",
     "calculate_overall_confidence",
     "InvalidExtractionData",
+    "InvalidTypedAgentData",
     "ExtractedFieldMetadata",
     "ExtractedFieldMetaDataDict",
 ]

--- a/py/llama_cloud_services/beta/agent_data/__init__.py
+++ b/py/llama_cloud_services/beta/agent_data/__init__.py
@@ -9,7 +9,6 @@ from .schema import (
     parse_extracted_field_metadata,
     calculate_overall_confidence,
     InvalidExtractionData,
-    InvalidTypedAgentData,
     ExtractedFieldMetadata,
     ExtractedFieldMetaDataDict,
 )
@@ -27,7 +26,6 @@ __all__ = [
     "parse_extracted_field_metadata",
     "calculate_overall_confidence",
     "InvalidExtractionData",
-    "InvalidTypedAgentData",
     "ExtractedFieldMetadata",
     "ExtractedFieldMetaDataDict",
 ]

--- a/py/llama_cloud_services/beta/agent_data/client.py
+++ b/py/llama_cloud_services/beta/agent_data/client.py
@@ -1,6 +1,11 @@
 import os
-from typing import Any, Dict, Generic, List, Optional, Type, cast
+from typing import Any, Dict, Generic, List, Optional, Type
 
+from llama_cloud import (
+    AgentData,
+    PaginatedResponseAgentData,
+    PaginatedResponseAggregateGroup,
+)
 from llama_cloud.client import AsyncLlamaCloud
 from tenacity import (
     WrappedFn,
@@ -18,7 +23,6 @@ from .schema import (
     TypedAgentDataItems,
     TypedAggregateGroup,
     TypedAggregateGroupItems,
-    InvalidTypedAgentData,
 )
 
 
@@ -158,29 +162,14 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
 
     @agent_data_retry
     async def get_item(self, item_id: str) -> TypedAgentData[AgentDataT]:
-        raw_data = await self.client.beta.get_agent_data(
-            item_id=item_id,
-        )
-        return TypedAgentData.from_raw(raw_data, validator=self.type)
+        raw_data = await self.untyped_get_item(item_id)
+        return TypedAgentData.from_raw(raw_data, self.type)
 
     @agent_data_retry
-    async def untyped_get_item(self, item_id: str) -> TypedAgentData[Dict[str, Any]]:
-        raw_data = await self.client.beta.get_agent_data(
+    async def untyped_get_item(self, item_id: str) -> AgentData:
+        return await self.client.beta.get_agent_data(
             item_id=item_id,
         )
-        try:
-            typed = TypedAgentData.from_raw(raw_data, validator=self.type)
-            data_as_dict = typed.data.model_dump()
-            return TypedAgentData[Dict[str, Any]](
-                id=typed.id,
-                deployment_name=typed.deployment_name,
-                collection=typed.collection,
-                data=data_as_dict,
-                created_at=typed.created_at,
-                updated_at=typed.updated_at,
-            )
-        except InvalidTypedAgentData as e:
-            return e.invalid_item
 
     @agent_data_retry
     async def create_item(self, data: AgentDataT) -> TypedAgentData[AgentDataT]:
@@ -231,9 +220,7 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
             offset: Number of items to skip from the beginning. Defaults to 0.
             include_total: Whether to include the total count in the response. Defaults to False to improve performance. It's recommended to only request on the first page.
         """
-        raw = await self.client.beta.search_agent_data_api_v_1_beta_agent_data_search_post(
-            deployment_name=self.deployment_name,
-            collection=self.collection,
+        raw = await self.untyped_search(
             filter=filter,
             order_by=order_by,
             offset=offset,
@@ -256,8 +243,8 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
         offset: Optional[int] = None,
         page_size: Optional[int] = None,
         include_total: bool = False,
-    ) -> TypedAgentDataItems[Dict[str, Any]]:
-        raw = await self.client.beta.search_agent_data_api_v_1_beta_agent_data_search_post(
+    ) -> PaginatedResponseAgentData:
+        return await self.client.beta.search_agent_data_api_v_1_beta_agent_data_search_post(
             deployment_name=self.deployment_name,
             collection=self.collection,
             filter=filter,
@@ -265,30 +252,6 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
             offset=offset,
             page_size=page_size,
             include_total=include_total,
-        )
-
-        items: List[TypedAgentData[Dict[str, Any]]] = []
-        for item in raw.items:
-            try:
-                typed_item = TypedAgentData.from_raw(item, validator=self.type)
-                data_as_dict = typed_item.data.model_dump()
-                items.append(
-                    TypedAgentData[Dict[str, Any]](
-                        id=typed_item.id,
-                        deployment_name=typed_item.deployment_name,
-                        collection=typed_item.collection,
-                        data=data_as_dict,
-                        created_at=typed_item.created_at,
-                        updated_at=typed_item.updated_at,
-                    )
-                )
-            except InvalidTypedAgentData as e:
-                items.append(e.invalid_item)
-
-        return TypedAgentDataItems(
-            items=items,
-            has_more=raw.next_page_token is not None,
-            total=raw.total_size,
         )
 
     @agent_data_retry
@@ -317,21 +280,20 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
             offset: Number of groups to skip from the beginning. Defaults to 0.
             page_size: Maximum number of groups to return per page.
         """
-        raw = await self.client.beta.aggregate_agent_data_api_v_1_beta_agent_data_aggregate_post(
-            deployment_name=self.deployment_name,
-            collection=self.collection,
-            page_size=page_size,
+        raw = await self.untyped_aggregate(
             filter=filter,
-            order_by=order_by,
             group_by=group_by,
             count=count,
             first=first,
+            order_by=order_by,
             offset=offset,
+            page_size=page_size,
         )
+
         return TypedAggregateGroupItems(
             items=[
-                TypedAggregateGroup.from_raw(item, validator=self.type)
-                for item in raw.items
+                TypedAggregateGroup.from_raw(grp, validator=self.type)
+                for grp in raw.items
             ],
             has_more=raw.next_page_token is not None,
             total=raw.total_size,
@@ -347,8 +309,8 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
         order_by: Optional[str] = None,
         offset: Optional[int] = None,
         page_size: Optional[int] = None,
-    ) -> TypedAggregateGroupItems[Dict[str, Any]]:
-        raw = await self.client.beta.aggregate_agent_data_api_v_1_beta_agent_data_aggregate_post(
+    ) -> PaginatedResponseAggregateGroup:
+        return await self.client.beta.aggregate_agent_data_api_v_1_beta_agent_data_aggregate_post(
             deployment_name=self.deployment_name,
             collection=self.collection,
             page_size=page_size,
@@ -358,41 +320,4 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
             count=count,
             first=first,
             offset=offset,
-        )
-
-        groups: List[TypedAggregateGroup[Dict[str, Any]]] = []
-        for grp in raw.items:
-            # Try to use typed transform first
-            try:
-                typed_grp = TypedAggregateGroup.from_raw(grp, validator=self.type)
-                first_item_dict: Optional[Dict[str, Any]] = None
-                if typed_grp.first_item is not None:
-                    first_item_dict = cast(Any, typed_grp.first_item).model_dump()
-                groups.append(
-                    TypedAggregateGroup[Dict[str, Any]](
-                        group_key=typed_grp.group_key,
-                        count=typed_grp.count,
-                        first_item=first_item_dict,
-                    )
-                )
-            except Exception:
-                # Fallback: use raw first_item as dict if possible
-                first_item_raw = grp.first_item if hasattr(grp, "first_item") else None
-                first_item_dict = None
-                if isinstance(first_item_raw, dict):
-                    first_item_dict = dict(first_item_raw)
-                elif hasattr(first_item_raw, "model_dump"):
-                    first_item_dict = cast(Any, first_item_raw).model_dump()
-                groups.append(
-                    TypedAggregateGroup[Dict[str, Any]](
-                        group_key=grp.group_key,
-                        count=grp.count,
-                        first_item=first_item_dict,
-                    )
-                )
-
-        return TypedAggregateGroupItems(
-            items=groups,
-            has_more=raw.next_page_token is not None,
-            total=raw.total_size,
         )

--- a/py/llama_cloud_services/beta/agent_data/client.py
+++ b/py/llama_cloud_services/beta/agent_data/client.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, Generic, List, Optional, Type
+from typing import Any, Dict, Generic, List, Optional, Type, cast
 
 from llama_cloud.client import AsyncLlamaCloud
 from tenacity import (
@@ -18,6 +18,7 @@ from .schema import (
     TypedAgentDataItems,
     TypedAggregateGroup,
     TypedAggregateGroupItems,
+    InvalidTypedAgentData,
 )
 
 
@@ -163,6 +164,25 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
         return TypedAgentData.from_raw(raw_data, validator=self.type)
 
     @agent_data_retry
+    async def untyped_get_item(self, item_id: str) -> TypedAgentData[Dict[str, Any]]:
+        raw_data = await self.client.beta.get_agent_data(
+            item_id=item_id,
+        )
+        try:
+            typed = TypedAgentData.from_raw(raw_data, validator=self.type)
+            data_as_dict = typed.data.model_dump()
+            return TypedAgentData[Dict[str, Any]](
+                id=typed.id,
+                deployment_name=typed.deployment_name,
+                collection=typed.collection,
+                data=data_as_dict,
+                created_at=typed.created_at,
+                updated_at=typed.updated_at,
+            )
+        except InvalidTypedAgentData as e:
+            return e.invalid_item
+
+    @agent_data_retry
     async def create_item(self, data: AgentDataT) -> TypedAgentData[AgentDataT]:
         raw_data = await self.client.beta.create_agent_data(
             deployment_name=self.deployment_name,
@@ -229,6 +249,49 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
         )
 
     @agent_data_retry
+    async def untyped_search(
+        self,
+        filter: Optional[Dict[str, Dict[ComparisonOperator, Any]]] = None,
+        order_by: Optional[str] = None,
+        offset: Optional[int] = None,
+        page_size: Optional[int] = None,
+        include_total: bool = False,
+    ) -> TypedAgentDataItems[Dict[str, Any]]:
+        raw = await self.client.beta.search_agent_data_api_v_1_beta_agent_data_search_post(
+            deployment_name=self.deployment_name,
+            collection=self.collection,
+            filter=filter,
+            order_by=order_by,
+            offset=offset,
+            page_size=page_size,
+            include_total=include_total,
+        )
+
+        items: List[TypedAgentData[Dict[str, Any]]] = []
+        for item in raw.items:
+            try:
+                typed_item = TypedAgentData.from_raw(item, validator=self.type)
+                data_as_dict = typed_item.data.model_dump()
+                items.append(
+                    TypedAgentData[Dict[str, Any]](
+                        id=typed_item.id,
+                        deployment_name=typed_item.deployment_name,
+                        collection=typed_item.collection,
+                        data=data_as_dict,
+                        created_at=typed_item.created_at,
+                        updated_at=typed_item.updated_at,
+                    )
+                )
+            except InvalidTypedAgentData as e:
+                items.append(e.invalid_item)
+
+        return TypedAgentDataItems(
+            items=items,
+            has_more=raw.next_page_token is not None,
+            total=raw.total_size,
+        )
+
+    @agent_data_retry
     async def aggregate(
         self,
         filter: Optional[Dict[str, Dict[ComparisonOperator, Any]]] = None,
@@ -270,6 +333,66 @@ class AsyncAgentDataClient(Generic[AgentDataT]):
                 TypedAggregateGroup.from_raw(item, validator=self.type)
                 for item in raw.items
             ],
+            has_more=raw.next_page_token is not None,
+            total=raw.total_size,
+        )
+
+    @agent_data_retry
+    async def untyped_aggregate(
+        self,
+        filter: Optional[Dict[str, Dict[ComparisonOperator, Any]]] = None,
+        group_by: Optional[List[str]] = None,
+        count: Optional[bool] = None,
+        first: Optional[bool] = None,
+        order_by: Optional[str] = None,
+        offset: Optional[int] = None,
+        page_size: Optional[int] = None,
+    ) -> TypedAggregateGroupItems[Dict[str, Any]]:
+        raw = await self.client.beta.aggregate_agent_data_api_v_1_beta_agent_data_aggregate_post(
+            deployment_name=self.deployment_name,
+            collection=self.collection,
+            page_size=page_size,
+            filter=filter,
+            order_by=order_by,
+            group_by=group_by,
+            count=count,
+            first=first,
+            offset=offset,
+        )
+
+        groups: List[TypedAggregateGroup[Dict[str, Any]]] = []
+        for grp in raw.items:
+            # Try to use typed transform first
+            try:
+                typed_grp = TypedAggregateGroup.from_raw(grp, validator=self.type)
+                first_item_dict: Optional[Dict[str, Any]] = None
+                if typed_grp.first_item is not None:
+                    first_item_dict = cast(Any, typed_grp.first_item).model_dump()
+                groups.append(
+                    TypedAggregateGroup[Dict[str, Any]](
+                        group_key=typed_grp.group_key,
+                        count=typed_grp.count,
+                        first_item=first_item_dict,
+                    )
+                )
+            except Exception:
+                # Fallback: use raw first_item as dict if possible
+                first_item_raw = grp.first_item if hasattr(grp, "first_item") else None
+                first_item_dict = None
+                if isinstance(first_item_raw, dict):
+                    first_item_dict = dict(first_item_raw)
+                elif hasattr(first_item_raw, "model_dump"):
+                    first_item_dict = cast(Any, first_item_raw).model_dump()
+                groups.append(
+                    TypedAggregateGroup[Dict[str, Any]](
+                        group_key=grp.group_key,
+                        count=grp.count,
+                        first_item=first_item_dict,
+                    )
+                )
+
+        return TypedAggregateGroupItems(
+            items=groups,
             has_more=raw.next_page_token is not None,
             total=raw.total_size,
         )

--- a/py/llama_cloud_services/beta/agent_data/schema.py
+++ b/py/llama_cloud_services/beta/agent_data/schema.py
@@ -56,7 +56,6 @@ from typing import (
 
 # Type variable for user-defined data models
 AgentDataT = TypeVar("AgentDataT", bound=BaseModel)
-
 # Type variable for extracted data (can be dict or Pydantic model)
 ExtractedT = TypeVar("ExtractedT", bound=Union[BaseModel, dict])
 
@@ -116,49 +115,19 @@ class TypedAgentData(BaseModel, Generic[AgentDataT]):
         Args:
             raw_data: Raw agent data from the API
             validator: Pydantic model class to validate the data field
-
         Returns:
             TypedAgentData instance with validated data
         """
-        try:
-            data: AgentDataT = validator.model_validate(raw_data.data)
 
-            return cls(
-                id=raw_data.id,
-                deployment_name=raw_data.deployment_name,
-                collection=raw_data.collection,
-                data=data,
-                created_at=raw_data.created_at,
-                updated_at=raw_data.updated_at,
-            )
-        except ValidationError as e:
-            # Attempt to coerce into untyped dict payload
-            if not isinstance(raw_data.data, dict):
-                # Could not coerce to dict – bubble up original validation error
-                raise e
+        data: AgentDataT = validator.model_validate(raw_data.data)
 
-            untyped: Dict[str, Any] = dict(raw_data.data)
-            invalid_item = TypedAgentData[Dict[str, Any]](
-                id=raw_data.id,
-                deployment_name=raw_data.deployment_name,
-                collection=raw_data.collection,
-                data=untyped,
-                created_at=raw_data.created_at,
-                updated_at=raw_data.updated_at,
-            )
-            raise InvalidTypedAgentData(invalid_item) from e
-
-
-class InvalidTypedAgentData(Exception):
-    """
-    Exception raised when agent data cannot be validated against the typed model
-    but can be represented as an untyped dictionary.
-    """
-
-    def __init__(self, invalid_item: "TypedAgentData[Dict[str, Any]]"):
-        self.invalid_item = invalid_item
-        super().__init__(
-            "Not able to parse the agent data into the typed model; returning untyped representation"
+        return cls(
+            id=raw_data.id,
+            deployment_name=raw_data.deployment_name,
+            collection=raw_data.collection,
+            data=data,
+            created_at=raw_data.created_at,
+            updated_at=raw_data.updated_at,
         )
 
 

--- a/py/llama_cloud_services/beta/agent_data/schema.py
+++ b/py/llama_cloud_services/beta/agent_data/schema.py
@@ -120,15 +120,45 @@ class TypedAgentData(BaseModel, Generic[AgentDataT]):
         Returns:
             TypedAgentData instance with validated data
         """
-        data: AgentDataT = validator.model_validate(raw_data.data)
+        try:
+            data: AgentDataT = validator.model_validate(raw_data.data)
 
-        return cls(
-            id=raw_data.id,
-            deployment_name=raw_data.deployment_name,
-            collection=raw_data.collection,
-            data=data,
-            created_at=raw_data.created_at,
-            updated_at=raw_data.updated_at,
+            return cls(
+                id=raw_data.id,
+                deployment_name=raw_data.deployment_name,
+                collection=raw_data.collection,
+                data=data,
+                created_at=raw_data.created_at,
+                updated_at=raw_data.updated_at,
+            )
+        except ValidationError as e:
+            # Attempt to coerce into untyped dict payload
+            if not isinstance(raw_data.data, dict):
+                # Could not coerce to dict – bubble up original validation error
+                raise e
+
+            untyped: Dict[str, Any] = dict(raw_data.data)
+            invalid_item = TypedAgentData[Dict[str, Any]](
+                id=raw_data.id,
+                deployment_name=raw_data.deployment_name,
+                collection=raw_data.collection,
+                data=untyped,
+                created_at=raw_data.created_at,
+                updated_at=raw_data.updated_at,
+            )
+            raise InvalidTypedAgentData(invalid_item) from e
+
+
+class InvalidTypedAgentData(Exception):
+    """
+    Exception raised when agent data cannot be validated against the typed model
+    but can be represented as an untyped dictionary.
+    """
+
+    def __init__(self, invalid_item: "TypedAgentData[Dict[str, Any]]"):
+        self.invalid_item = invalid_item
+        super().__init__(
+            "Not able to parse the agent data into the typed model; returning untyped representation"
         )
 
 

--- a/py/unit_tests/beta/agent/test_agent_data_client_untyped.py
+++ b/py/unit_tests/beta/agent/test_agent_data_client_untyped.py
@@ -40,7 +40,12 @@ class FakeBeta:
         include_total: bool = False,
     ) -> Any:
         class Resp:
-            def __init__(self, items: List[AgentData], total_size: Optional[int], next_page_token: Optional[str]) -> None:
+            def __init__(
+                self,
+                items: List[AgentData],
+                total_size: Optional[int],
+                next_page_token: Optional[str],
+            ) -> None:
                 self.items = items
                 self.total_size = total_size
                 self.next_page_token = next_page_token
@@ -62,7 +67,12 @@ class FakeBeta:
         offset: Optional[int] = None,
     ) -> Any:
         class Resp:
-            def __init__(self, items: List[AggregateGroup], total_size: Optional[int], next_page_token: Optional[str]) -> None:
+            def __init__(
+                self,
+                items: List[AggregateGroup],
+                total_size: Optional[int],
+                next_page_token: Optional[str],
+            ) -> None:
                 self.items = items
                 self.total_size = total_size
                 self.next_page_token = next_page_token
@@ -86,7 +96,11 @@ def make_agent_data(data: Dict[str, Any]) -> AgentData:
     )
 
 
-def make_group(group_key: Dict[str, Any], first_item: Optional[Dict[str, Any]], count: Optional[int] = None) -> AggregateGroup:
+def make_group(
+    group_key: Dict[str, Any],
+    first_item: Optional[Dict[str, Any]],
+    count: Optional[int] = None,
+) -> AggregateGroup:
     return AggregateGroup(group_key=group_key, count=count, first_item=first_item)
 
 
@@ -125,7 +139,7 @@ async def test_untyped_search_mixed_items() -> None:
     assert len(results.items) == 2
     assert results.items[0].data == {"name": "Carol", "age": 22}
     assert results.items[1].data == {"name": "Dave", "age": "bad"}
-    assert results.total == 2
+    assert results.total_size == 2
 
 
 @pytest.mark.asyncio

--- a/py/unit_tests/beta/agent/test_agent_data_client_untyped.py
+++ b/py/unit_tests/beta/agent/test_agent_data_client_untyped.py
@@ -1,0 +1,144 @@
+import pytest
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel
+from datetime import datetime
+
+from llama_cloud.types.agent_data import AgentData
+from llama_cloud.types.aggregate_group import AggregateGroup
+
+from llama_cloud_services.beta.agent_data.client import AsyncAgentDataClient
+
+
+class Person(BaseModel):
+    name: str
+    age: int
+
+
+class FakeBeta:
+    def __init__(self) -> None:
+        self._get_item_response: Optional[AgentData] = None
+        self._search_items: List[AgentData] = []
+        self._aggregate_items: List[AggregateGroup] = []
+        self._total_size: Optional[int] = None
+        self._next_page_token: Optional[str] = None
+
+    # Single get
+    async def get_agent_data(self, item_id: str) -> AgentData:
+        assert self._get_item_response is not None, "_get_item_response not set"
+        return self._get_item_response
+
+    # Search
+    async def search_agent_data_api_v_1_beta_agent_data_search_post(
+        self,
+        *,
+        deployment_name: str,
+        collection: str,
+        filter: Optional[Dict[str, Any]] = None,
+        order_by: Optional[str] = None,
+        offset: Optional[int] = None,
+        page_size: Optional[int] = None,
+        include_total: bool = False,
+    ) -> Any:
+        class Resp:
+            def __init__(self, items: List[AgentData], total_size: Optional[int], next_page_token: Optional[str]) -> None:
+                self.items = items
+                self.total_size = total_size
+                self.next_page_token = next_page_token
+
+        return Resp(self._search_items, self._total_size, self._next_page_token)
+
+    # Aggregate
+    async def aggregate_agent_data_api_v_1_beta_agent_data_aggregate_post(
+        self,
+        *,
+        deployment_name: str,
+        collection: str,
+        page_size: Optional[int] = None,
+        filter: Optional[Dict[str, Any]] = None,
+        order_by: Optional[str] = None,
+        group_by: Optional[List[str]] = None,
+        count: Optional[bool] = None,
+        first: Optional[bool] = None,
+        offset: Optional[int] = None,
+    ) -> Any:
+        class Resp:
+            def __init__(self, items: List[AggregateGroup], total_size: Optional[int], next_page_token: Optional[str]) -> None:
+                self.items = items
+                self.total_size = total_size
+                self.next_page_token = next_page_token
+
+        return Resp(self._aggregate_items, self._total_size, self._next_page_token)
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.beta = FakeBeta()
+
+
+def make_agent_data(data: Dict[str, Any]) -> AgentData:
+    return AgentData(
+        id="id-1",
+        deployment_name="dep",
+        collection="col",
+        data=data,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+
+def make_group(group_key: Dict[str, Any], first_item: Optional[Dict[str, Any]], count: Optional[int] = None) -> AggregateGroup:
+    return AggregateGroup(group_key=group_key, count=count, first_item=first_item)
+
+
+@pytest.mark.asyncio
+async def test_untyped_get_item_valid_to_dict() -> None:
+    client = FakeClient()
+    client.beta._get_item_response = make_agent_data({"name": "Alice", "age": 30})
+
+    adc = AsyncAgentDataClient(type=Person, client=client, deployment_name="dep")
+    item = await adc.untyped_get_item("id-1")
+    assert item.data == {"name": "Alice", "age": 30}
+
+
+@pytest.mark.asyncio
+async def test_untyped_get_item_invalid_retains_dict() -> None:
+    client = FakeClient()
+    # age wrong type; will fail validation and should be returned as dict
+    client.beta._get_item_response = make_agent_data({"name": "Bob", "age": "x"})
+
+    adc = AsyncAgentDataClient(type=Person, client=client, deployment_name="dep")
+    item = await adc.untyped_get_item("id-1")
+    assert item.data == {"name": "Bob", "age": "x"}
+
+
+@pytest.mark.asyncio
+async def test_untyped_search_mixed_items() -> None:
+    client = FakeClient()
+    client.beta._search_items = [
+        make_agent_data({"name": "Carol", "age": 22}),
+        make_agent_data({"name": "Dave", "age": "bad"}),
+    ]
+    client.beta._total_size = 2
+
+    adc = AsyncAgentDataClient(type=Person, client=client, deployment_name="dep")
+    results = await adc.untyped_search(include_total=True)
+    assert len(results.items) == 2
+    assert results.items[0].data == {"name": "Carol", "age": 22}
+    assert results.items[1].data == {"name": "Dave", "age": "bad"}
+    assert results.total == 2
+
+
+@pytest.mark.asyncio
+async def test_untyped_aggregate_first_item_dict() -> None:
+    client = FakeClient()
+    client.beta._aggregate_items = [
+        make_group({"k": 1}, {"name": "Eve", "age": 40}),
+        make_group({"k": 2}, {"name": "Frank", "age": "bad"}),
+    ]
+    client.beta._total_size = 2
+
+    adc = AsyncAgentDataClient(type=Person, client=client, deployment_name="dep")
+    results = await adc.untyped_aggregate(group_by=["k"], first=True)
+    assert len(results.items) == 2
+    assert results.items[0].first_item == {"name": "Eve", "age": 40}
+    assert results.items[1].first_item == {"name": "Frank", "age": "bad"}

--- a/py/unit_tests/beta/agent/test_agent_data_schema.py
+++ b/py/unit_tests/beta/agent/test_agent_data_schema.py
@@ -7,14 +7,13 @@ import pytest
 from llama_cloud import ExtractRun, File
 from llama_cloud.types.agent_data import AgentData
 from llama_cloud.types.aggregate_group import AggregateGroup
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from llama_cloud_services.beta.agent_data.schema import (
     ExtractedData,
     ExtractedFieldMetadata,
     FieldCitation,
     InvalidExtractionData,
-    InvalidTypedAgentData,
     TypedAgentData,
     TypedAggregateGroup,
     calculate_overall_confidence,
@@ -67,11 +66,8 @@ def test_typed_agent_data_from_raw_validation_error():
         updated_at=datetime.now(),
     )
 
-    with pytest.raises(InvalidTypedAgentData) as exc:
+    with pytest.raises(ValidationError):
         TypedAgentData.from_raw(raw_data, Person)
-    # The exception should carry the untyped item
-    invalid_item = exc.value.invalid_item
-    assert invalid_item.data == {"name": "Invalid Person", "age": "not_a_number"}
 
 
 def test_extracted_data_create_method():

--- a/py/unit_tests/beta/agent/test_agent_data_schema.py
+++ b/py/unit_tests/beta/agent/test_agent_data_schema.py
@@ -7,13 +7,14 @@ import pytest
 from llama_cloud import ExtractRun, File
 from llama_cloud.types.agent_data import AgentData
 from llama_cloud.types.aggregate_group import AggregateGroup
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
 
 from llama_cloud_services.beta.agent_data.schema import (
     ExtractedData,
     ExtractedFieldMetadata,
     FieldCitation,
     InvalidExtractionData,
+    InvalidTypedAgentData,
     TypedAgentData,
     TypedAggregateGroup,
     calculate_overall_confidence,
@@ -56,7 +57,7 @@ def test_typed_agent_data_from_raw():
 
 
 def test_typed_agent_data_from_raw_validation_error():
-    """Test TypedAgentData.from_raw with invalid data."""
+    """Test TypedAgentData.from_raw with invalid data now raises InvalidTypedAgentData."""
     raw_data = AgentData(
         id="789",
         deployment_name="test-agent",
@@ -66,8 +67,11 @@ def test_typed_agent_data_from_raw_validation_error():
         updated_at=datetime.now(),
     )
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidTypedAgentData) as exc:
         TypedAgentData.from_raw(raw_data, Person)
+    # The exception should carry the untyped item
+    invalid_item = exc.value.invalid_item
+    assert invalid_item.data == {"name": "Invalid Person", "age": "not_a_number"}
 
 
 def test_extracted_data_create_method():

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1596,7 +1596,7 @@ wheels = [
 
 [[package]]
 name = "llama-cloud-services"
-version = "0.6.67"
+version = "0.6.68"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Add alternate untyped agent data retrieval methods so that type errors can be more gracefully handled

Without exposing methods that don't crash on invalid types, its easy to get backed into a corner with errors, e.g. if trying to load old data before deleting it after changing a schema.