### PR TITLE
Implement test plan and create mocked tests

### DIFF
--- a/py/llama_cloud_services/__init__.py
+++ b/py/llama_cloud_services/__init__.py
@@ -1,5 +1,6 @@
 from llama_cloud_services.parse import LlamaParse
 from llama_cloud_services.extract import LlamaExtract, ExtractionAgent
+from llama_cloud_services.testing_utils import FakeLlamaCloudServer
 from llama_cloud_services.utils import SourceText, FileInput
 from llama_cloud_services.constants import EU_BASE_URL
 from llama_cloud_services.index import (
@@ -18,4 +19,5 @@ __all__ = [
     "LlamaCloudIndex",
     "LlamaCloudRetriever",
     "LlamaCloudCompositeRetriever",
+    "FakeLlamaCloudServer",
 ]

--- a/py/llama_cloud_services/testing_utils/__init__.py
+++ b/py/llama_cloud_services/testing_utils/__init__.py
@@ -1,0 +1,9 @@
+from .matchers import FileMatcher, RequestMatcher, SchemaMatcher
+from .server import FakeLlamaCloudServer
+
+__all__ = [
+    "FakeLlamaCloudServer",
+    "FileMatcher",
+    "SchemaMatcher",
+    "RequestMatcher",
+]

--- a/py/llama_cloud_services/testing_utils/_deterministic.py
+++ b/py/llama_cloud_services/testing_utils/_deterministic.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, MutableMapping
+
+
+def hash_chunks(chunks: Iterable[bytes]) -> str:
+    digest = hashlib.sha256()
+    for chunk in chunks:
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
+def fingerprint_file(content: bytes, filename: str | None = None) -> str:
+    name_bytes = filename.encode("utf-8") if filename else b""
+    return hash_chunks((content, name_bytes))
+
+
+def hash_schema(schema: Any) -> str:
+    json_string = json.dumps(
+        _to_serializable(schema),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(json_string.encode("utf-8")).hexdigest()
+
+
+def combined_seed(*parts: str) -> int:
+    digest = hash_chunks(tuple(part.encode("utf-8") for part in parts))
+    return int(digest[:16], 16)
+
+
+def generate_data_from_schema(schema: Any, seed: int) -> Any:
+    rng = random.Random(seed)
+    return _generate_value(schema, rng, depth=0)
+
+
+def generate_text_blob(seed: int, sentences: int = 3) -> str:
+    rng = random.Random(seed)
+    words = [
+        "aurora",
+        "copper",
+        "delta",
+        "ember",
+        "fable",
+        "glyph",
+        "harbor",
+        "iris",
+        "juniper",
+        "kepler",
+        "lumen",
+        "monarch",
+        "nylon",
+        "onyx",
+        "paragon",
+        "quartz",
+        "raptor",
+        "solstice",
+        "topaz",
+        "umbra",
+        "verdant",
+        "willow",
+        "xenon",
+        "yonder",
+        "zephyr",
+    ]
+    sentence_pieces = []
+    for _ in range(sentences):
+        length = rng.randint(6, 12)
+        chosen = rng.sample(words, k=length)
+        sentence = " ".join(chosen).capitalize() + "."
+        sentence_pieces.append(sentence)
+    return " ".join(sentence_pieces)
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _to_serializable(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="ignore")
+    if isinstance(value, Mapping):
+        return {key: _to_serializable(val) for key, val in value.items()}
+    if isinstance(value, MutableMapping):
+        return {key: _to_serializable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_to_serializable(item) for item in value]
+    if hasattr(value, "model_dump_json"):
+        return json.loads(value.model_dump_json())
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    if hasattr(value, "dict"):
+        return value.dict()  # type: ignore[call-arg]
+    if hasattr(value, "model_json_schema"):
+        return value.model_json_schema()
+    return str(value)
+
+
+def _generate_value(schema: Any, rng: random.Random, depth: int) -> Any:
+    if depth > 8:
+        return rng.choice(
+            (
+                rng.randint(1, 999),
+                rng.random(),
+                generate_text_blob(rng.randint(0, 1_000_000), sentences=1),
+            )
+        )
+
+    if schema is None:
+        return generate_text_blob(rng.randint(0, 1_000_000), sentences=1)
+
+    if isinstance(schema, list):
+        return [_generate_value(item, rng, depth + 1) for item in schema]
+
+    if isinstance(schema, str):
+        return f"{schema}-{rng.randint(100, 999)}"
+
+    if isinstance(schema, Mapping):
+        if "enum" in schema:
+            options = schema["enum"]
+            if options:
+                index = rng.randint(0, len(options) - 1)
+                return options[index]
+
+        schema_type = schema.get("type")
+
+        if schema_type == "object":
+            properties = schema.get("properties", {})
+            result = {}
+            for key, subschema in properties.items():
+                result[key] = _generate_value(subschema, rng, depth + 1)
+            return result
+
+        if schema_type == "array":
+            items_schema = schema.get("items", {})
+            min_items = schema.get("minItems", 1)
+            max_items = schema.get("maxItems", max(3, min_items))
+            length = rng.randint(min_items, min(min_items + 2, max_items))
+            return [_generate_value(items_schema, rng, depth + 1) for _ in range(length)]
+
+        if schema_type == "integer":
+            minimum = schema.get("minimum", 0)
+            maximum = schema.get("maximum", minimum + 500)
+            return rng.randint(int(minimum), int(maximum))
+
+        if schema_type == "number":
+            minimum = schema.get("minimum", 0.0)
+            maximum = schema.get("maximum", minimum + 500.0)
+            value = rng.uniform(float(minimum), float(maximum))
+            return round(value, 2)
+
+        if schema_type == "boolean":
+            return rng.choice((True, False))
+
+        if schema_type == "string":
+            fmt = schema.get("format")
+            if fmt == "date-time":
+                timestamp = utcnow().isoformat()
+                return timestamp
+            if fmt == "email":
+                return f"user{rng.randint(1000, 9999)}@example.com"
+            if fmt == "uri":
+                return f"https://example.com/{rng.randint(1000, 9999)}"
+            min_length = schema.get("minLength", 5)
+            max_length = schema.get("maxLength", max(10, min_length))
+            length = rng.randint(min_length, min(min_length + 5, max_length))
+            return generate_text_blob(rng.randint(0, 1_000_000), sentences=max(1, length // 5))
+
+        if "oneOf" in schema:
+            option = rng.choice(schema["oneOf"])
+            return _generate_value(option, rng, depth + 1)
+
+        if "anyOf" in schema:
+            option = rng.choice(schema["anyOf"])
+            return _generate_value(option, rng, depth + 1)
+
+    return generate_text_blob(rng.randint(0, 1_000_000), sentences=1)
+

--- a/py/llama_cloud_services/testing_utils/classify.py
+++ b/py/llama_cloud_services/testing_utils/classify.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List
+
+import httpx
+from llama_cloud.types import (
+    ClassifierRule,
+    ClassifyJob,
+    ClassifyJobResults,
+    ClassificationResult,
+    FileClassification,
+    StatusEnum,
+)
+
+from ._deterministic import combined_seed, utcnow
+from .files import FakeFilesNamespace, StoredFile
+
+if TYPE_CHECKING:
+    from .server import FakeLlamaCloudServer
+
+
+@dataclass(slots=True)
+class ClassificationJobRecord:
+    job: ClassifyJob
+    results: ClassifyJobResults
+    files: List[StoredFile]
+
+
+class FakeClassifyNamespace:
+    def __init__(self, *, server: "FakeLlamaCloudServer", files: FakeFilesNamespace) -> None:
+        self._server = server
+        self._files = files
+        self._jobs: Dict[str, ClassificationJobRecord] = {}
+
+    def register(self) -> None:
+        server = self._server
+        server.add_route(
+            "POST",
+            "/api/v1/classifier/jobs",
+            self._handle_create_job,
+            namespace="classify",
+        )
+        server.add_route(
+            "GET",
+            "/api/v1/classifier/jobs",
+            self._handle_list_jobs,
+            namespace="classify",
+        )
+        server.add_route(
+            "GET",
+            "/api/v1/classifier/jobs/{job_id}",
+            self._handle_get_job,
+            namespace="classify",
+        )
+        server.add_route(
+            "GET",
+            "/api/v1/classifier/jobs/{job_id}/results",
+            self._handle_get_results,
+            namespace="classify",
+        )
+
+    def _handle_create_job(self, request: httpx.Request) -> httpx.Response:
+        payload = self._server.json(request)
+        file_ids = payload.get("file_ids", [])
+        rules_payload = payload.get("rules", [])
+        rules = [ClassifierRule.parse_obj(rule) for rule in rules_payload]
+        stored_files = []
+        for file_id in file_ids:
+            stored = self._files.get(file_id)
+            if not stored:
+                return self._server.json_response({"detail": f"File {file_id} not found"}, status_code=404)
+            stored_files.append(stored)
+
+        job_id = self._server.new_id("classify-job")
+        job = ClassifyJob(
+            id=job_id,
+            project_id=request.url.params.get("project_id", self._server.default_project_id),
+            user_id="fake-user",
+            rules=rules,
+            parsing_configuration=None,
+            status=StatusEnum.SUCCESS,
+            created_at=utcnow(),
+            updated_at=utcnow(),
+            effective_at=utcnow(),
+            error_message=None,
+            job_record_id=None,
+        )
+        results = self._build_results(job_id, stored_files, rules)
+        record = ClassificationJobRecord(job=job, results=results, files=stored_files)
+        self._jobs[job_id] = record
+        return self._server.json_response(job.dict())
+
+    def _handle_list_jobs(self, request: httpx.Request) -> httpx.Response:
+        return self._server.json_response([record.job.dict() for record in self._jobs.values()])
+
+    def _handle_get_job(self, request: httpx.Request) -> httpx.Response:
+        job_id = request.url.path.split("/")[-1]
+        record = self._jobs.get(job_id)
+        if not record:
+            return self._server.json_response({"detail": "Job not found"}, status_code=404)
+        return self._server.json_response(record.job.dict())
+
+    def _handle_get_results(self, request: httpx.Request) -> httpx.Response:
+        job_id = request.url.path.split("/")[-2]
+        record = self._jobs.get(job_id)
+        if not record:
+            return self._server.json_response({"detail": "Results not found"}, status_code=404)
+        return self._server.json_response(record.results.dict())
+
+    def _build_results(
+        self,
+        job_id: str,
+        stored_files: List[StoredFile],
+        rules: List[ClassifierRule],
+    ) -> ClassifyJobResults:
+        items: List[FileClassification] = []
+        for stored in stored_files:
+            seed = combined_seed(stored.sha256, job_id)
+            rule_index = seed % len(rules) if rules else 0
+            predicted_type = rules[rule_index].type if rules else "unlabeled"
+            confidence = 0.55 + (seed % 40) / 100
+            reasoning = f"Selected rule '{predicted_type}' using deterministic seed {seed}."
+            classification = FileClassification(
+                id=self._server.new_id("classification"),
+                file_id=stored.file.id,
+                classify_job_id=job_id,
+                created_at=utcnow(),
+                updated_at=utcnow(),
+                result=ClassificationResult(
+                    type=predicted_type,
+                    confidence=min(confidence, 0.95),
+                    reasoning=reasoning,
+                ),
+            )
+            items.append(classification)
+        return ClassifyJobResults(items=items, next_page_token=None, total_size=len(items))

--- a/py/llama_cloud_services/testing_utils/extract.py
+++ b/py/llama_cloud_services/testing_utils/extract.py
@@ -1,0 +1,633 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import httpx
+from llama_cloud.types import (
+    ExtractAgent,
+    ExtractConfig,
+    ExtractJob,
+    ExtractRun,
+    ExtractState,
+    File as CloudFile,
+    PaginatedExtractRunsResponse,
+    StatusEnum,
+)
+
+from ._deterministic import combined_seed, generate_data_from_schema, hash_schema, utcnow
+from ._deterministic import fingerprint_file
+from .files import FakeFilesNamespace, StoredFile
+from .matchers import RequestContext, RequestMatcher
+
+if TYPE_CHECKING:
+    from .server import FakeLlamaCloudServer
+
+
+@dataclass(slots=True)
+class ExtractRunStub:
+    matcher: Optional[RequestMatcher]
+    data: Optional[Any]
+    status: Optional[str]
+    metadata: Optional[Dict[str, Any]]
+    error: Optional[str]
+    job_status: Optional[str]
+    once: bool
+
+
+@dataclass(slots=True)
+class AgentRunStub:
+    agent_id: str
+    matcher: Optional[RequestMatcher]
+    job_status: Optional[str]
+    run_status: Optional[str]
+    error: Optional[str]
+    once: bool
+
+
+@dataclass(slots=True)
+class StoredRun:
+    job: ExtractJob
+    run: ExtractRun
+
+
+class FakeExtractNamespace:
+    def __init__(
+        self,
+        *,
+        server: "FakeLlamaCloudServer",
+        files: FakeFilesNamespace,
+    ) -> None:
+        self._server = server
+        self._files = files
+        self._jobs: Dict[str, StoredRun] = {}
+        self._runs: Dict[str, ExtractRun] = {}
+        self._agents: Dict[str, ExtractAgent] = {}
+        self._agents_by_name: Dict[str, str] = {}
+        self._run_stubs: List[ExtractRunStub] = []
+        self._agent_run_stubs: List[AgentRunStub] = []
+        self.routes: Dict[str, Any] = {}
+
+    # Public APIs ----------------------------------------------------
+    def stub_run(
+        self,
+        matcher: Optional[RequestMatcher],
+        *,
+        data: Optional[Any] = None,
+        status: Optional[str] = None,
+        job_status: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        error: Optional[str] = None,
+        once: bool = True,
+    ) -> None:
+        self._run_stubs.append(
+            ExtractRunStub(
+                matcher=matcher,
+                data=data,
+                status=status,
+                metadata=metadata,
+                error=error,
+                job_status=job_status,
+                once=once,
+            )
+        )
+
+    def stub_agent_run(
+        self,
+        *,
+        agent_id: str,
+        matcher: Optional[RequestMatcher],
+        job_status: Optional[str] = None,
+        run_status: Optional[str] = None,
+        error: Optional[str] = None,
+        once: bool = True,
+    ) -> None:
+        self._agent_run_stubs.append(
+            AgentRunStub(
+                agent_id=agent_id,
+                matcher=matcher,
+                job_status=job_status,
+                run_status=run_status,
+                error=error,
+                once=once,
+            )
+        )
+
+    # Route registration ---------------------------------------------
+    def register(self) -> None:
+        server = self._server
+        route = server.add_route(
+            "POST",
+            "/api/v1/extraction/run",
+            self._handle_stateless_run,
+            namespace="extract",
+            alias="extract_run",
+        )
+        self.routes["stateless_run"] = route
+        self.stateless_run = route
+        server.add_route(
+            "POST",
+            "/api/v1/extraction/extraction-agents",
+            self._handle_create_agent,
+            namespace="extract",
+        )
+        server.add_route(
+            "PATCH",
+            "/api/v1/extraction/extraction-agents/{agent_id}",
+            self._handle_update_agent,
+            namespace="extract",
+        )
+        server.add_route(
+            "GET",
+            "/api/v1/extraction/extraction-agents/{agent_id}",
+            self._handle_get_agent,
+            namespace="extract",
+        )
+        server.add_route(
+            "GET",
+            "/api/v1/extraction/extraction-agents/by-name/{name}",
+            self._handle_get_agent_by_name,
+            namespace="extract",
+        )
+        server.add_route(
+            "GET",
+            "/api/v1/extraction/extraction-agents",
+            self._handle_list_agents,
+            namespace="extract",
+        )
+        server.add_route(
+            "GET",
+            "/api/v1/extraction/extraction-agents/default",
+            self._handle_get_default_agent,
+            namespace="extract",
+        )
+        server.add_route(
+            "DELETE",
+            "/api/v1/extraction/extraction-agents/{agent_id}",
+            self._handle_delete_agent,
+            namespace="extract",
+        )
+        server.add_route(
+            "POST",
+            "/api/v1/extraction/extraction-agents/schema/validation",
+            self._handle_validate_schema,
+            namespace="extract",
+        )
+        agent_job_route = server.add_route(
+            "POST",
+            "/api/v1/extraction/jobs",
+            self._handle_agent_job,
+            namespace="extract",
+            alias="agent_job",
+        )
+        self.routes["agent_job"] = agent_job_route
+        self.agent_job = agent_job_route
+        server.add_route(
+            "POST",
+            "/api/v1/extraction/jobs/batch",
+            self._handle_agent_job_batch,
+            namespace="extract",
+        )
+        server.add_route(
+            "GET",
+            "/api/v1/extraction/jobs",
+            self._handle_list_jobs,
+            namespace="extract",
+        )
+        server.add_route(
+            "GET",
+            "/api/v1/extraction/jobs/{job_id}",
+            self._handle_get_job,
+            namespace="extract",
+        )
+        agent_run_route = server.add_route(
+            "GET",
+            "/api/v1/extraction/runs/by-job/{job_id}",
+            self._handle_get_run_by_job,
+            namespace="extract",
+            alias="agent_run",
+        )
+        self.routes["agent_run"] = agent_run_route
+        self.agent_run = agent_run_route
+        server.add_route(
+            "GET",
+            "/api/v1/extraction/runs/{run_id}",
+            self._handle_get_run,
+            namespace="extract",
+        )
+        server.add_route(
+            "DELETE",
+            "/api/v1/extraction/runs/{run_id}",
+            self._handle_delete_run,
+            namespace="extract",
+        )
+        server.add_route(
+            "GET",
+            "/api/v1/extraction/runs",
+            self._handle_list_runs,
+            namespace="extract",
+        )
+
+    # Handlers -------------------------------------------------------
+    def _handle_stateless_run(self, request: httpx.Request) -> httpx.Response:
+        payload = self._server.json(request)
+        config = ExtractConfig.parse_obj(payload["config"])
+        data_schema = payload["data_schema"]
+        schema_hash = hash_schema(data_schema)
+
+        file_info = self._extract_file_info(payload, request)
+        agent = self._build_ephemeral_agent(config, data_schema, file_info.file.project_id)
+
+        context = RequestContext(
+            request=request,
+            json=payload,
+            file_id=file_info.file.id,
+            filename=file_info.file.name,
+            file_sha256=file_info.sha256,
+            schema_hash=schema_hash,
+            project_id=file_info.file.project_id,
+            organization_id=self._server.default_organization_id,
+        )
+
+        stub = self._pop_stub(self._run_stubs, context)
+        job_status = StatusEnum.SUCCESS
+        run_status = ExtractState.SUCCESS
+        metadata = {"deterministic": {"value": True}}
+        error = None
+        run_data = self._generate_run_data(data_schema, file_info.sha256)
+
+        if stub:
+            if stub.job_status:
+                job_status = StatusEnum(stub.job_status)
+            if stub.status:
+                run_status = ExtractState(stub.status)
+            if stub.metadata:
+                metadata = stub.metadata
+            if stub.error:
+                error = stub.error
+            if stub.data is not None:
+                if callable(stub.data):
+                    run_data = stub.data(payload)  # type: ignore[assignment]
+                else:
+                    run_data = stub.data
+
+        stored = self._create_job_and_run(
+            agent=agent,
+            config=config,
+            data_schema=data_schema,
+            file_info=file_info,
+            job_status=job_status,
+            run_status=run_status,
+            metadata=metadata,
+            data=run_data,
+            error=error,
+            project_id=file_info.file.project_id,
+        )
+        return self._server.json_response(stored.job.dict())
+
+    def _handle_create_agent(self, request: httpx.Request) -> httpx.Response:
+        payload = self._server.json(request)
+        name = payload["name"]
+        config = ExtractConfig.parse_obj(payload["config"])
+        data_schema = payload["data_schema"]
+        agent_id = self._server.new_id("agent")
+        agent = ExtractAgent(
+            id=agent_id,
+            name=name,
+            config=config,
+            data_schema=data_schema,
+            project_id=request.url.params.get("project_id", self._server.default_project_id),
+            created_at=utcnow(),
+            updated_at=utcnow(),
+            custom_configuration=None,
+        )
+        self._agents[agent_id] = agent
+        self._agents_by_name[name] = agent_id
+        return self._server.json_response(agent.dict())
+
+    def _handle_update_agent(self, request: httpx.Request) -> httpx.Response:
+        agent_id = request.url.path.split("/")[-1]
+        if agent_id not in self._agents:
+            return self._server.json_response({"detail": "Agent not found"}, status_code=404)
+        payload = self._server.json(request)
+        agent = self._agents[agent_id]
+        config = payload.get("config", agent.config)
+        data_schema = payload.get("data_schema", agent.data_schema)
+        updated = agent.copy(
+            update={
+                "config": ExtractConfig.parse_obj(config) if isinstance(config, dict) else config,
+                "data_schema": data_schema,
+                "updated_at": utcnow(),
+            }
+        )
+        self._agents[agent_id] = updated
+        return self._server.json_response(updated.dict())
+
+    def _handle_get_agent(self, request: httpx.Request) -> httpx.Response:
+        agent_id = request.url.path.split("/")[-1]
+        agent = self._agents.get(agent_id)
+        if not agent:
+            return self._server.json_response({"detail": "Agent not found"}, status_code=404)
+        return self._server.json_response(agent.dict())
+
+    def _handle_get_agent_by_name(self, request: httpx.Request) -> httpx.Response:
+        name = request.url.path.split("/")[-1]
+        agent_id = self._agents_by_name.get(name)
+        if not agent_id:
+            return self._server.json_response({"detail": "Agent not found"}, status_code=404)
+        return self._server.json_response(self._agents[agent_id].dict())
+
+    def _handle_list_agents(self, request: httpx.Request) -> httpx.Response:
+        include_default = request.url.params.get("include_default", "false").lower() == "true"
+        agents = list(self._agents.values())
+        if include_default and not agents:
+            default_agent = self._build_ephemeral_agent(
+                ExtractConfig(),
+                {"type": "object", "properties": {}},
+                self._server.default_project_id,
+            )
+            agents.append(default_agent)
+        return self._server.json_response([agent.dict() for agent in agents])
+
+    def _handle_get_default_agent(self, request: httpx.Request) -> httpx.Response:
+        if self._agents:
+            agent = next(iter(self._agents.values()))
+        else:
+            agent = self._build_ephemeral_agent(
+                ExtractConfig(),
+                {"type": "object", "properties": {}},
+                self._server.default_project_id,
+            )
+        return self._server.json_response(agent.dict())
+
+    def _handle_delete_agent(self, request: httpx.Request) -> httpx.Response:
+        agent_id = request.url.path.split("/")[-1]
+        agent = self._agents.pop(agent_id, None)
+        if agent:
+            self._agents_by_name.pop(agent.name, None)
+        return self._server.json_response({}, status_code=200)
+
+    def _handle_validate_schema(self, request: httpx.Request) -> httpx.Response:
+        payload = self._server.json(request)
+        return self._server.json_response({"data_schema": payload["data_schema"]})
+
+    def _handle_agent_job(self, request: httpx.Request) -> httpx.Response:
+        payload = self._server.json(request)
+        agent_id = payload["extraction_agent_id"]
+        agent = self._agents.get(agent_id)
+        if not agent:
+            return self._server.json_response({"detail": "Agent not found"}, status_code=404)
+
+        file_id = payload["file_id"]
+        stored_file = self._files._files.get(file_id)
+        if not stored_file:
+            return self._server.json_response({"detail": "File not found"}, status_code=404)
+
+        schema = payload.get("data_schema_override", agent.data_schema)
+        config_payload = payload.get("config_override", agent.config)
+        config = ExtractConfig.parse_obj(config_payload) if isinstance(config_payload, dict) else config_payload
+        schema_hash = hash_schema(schema)
+
+        stub = self._pop_agent_stub(agent_id, RequestContext(request=request, json=payload))
+        job_status = StatusEnum.SUCCESS
+        run_status = ExtractState.SUCCESS
+        error = None
+        if stub:
+            if stub.job_status:
+                job_status = StatusEnum(stub.job_status)
+            if stub.run_status:
+                run_status = ExtractState(stub.run_status)
+            if stub.error:
+                error = stub.error
+
+        stored = self._create_job_and_run(
+            agent=agent,
+            config=config,
+            data_schema=schema,
+            file_info=stored_file,
+            job_status=job_status,
+            run_status=run_status,
+            metadata={"agent": {"value": agent.id}},
+            data=self._generate_run_data(schema, stored_file.sha256),
+            error=error,
+            project_id=agent.project_id,
+        )
+        return self._server.json_response(stored.job.dict())
+
+    def _handle_agent_job_batch(self, request: httpx.Request) -> httpx.Response:
+        payload = self._server.json(request)
+        file_ids = payload.get("file_ids", [])
+        jobs = []
+        for file_id in file_ids:
+            request_body = payload.copy()
+            request_body["file_id"] = file_id
+            fake_request = request.copy()
+            fake_request._content = self._server.encode_json(request_body)
+            response = self._handle_agent_job(fake_request)
+            if response.status_code != 200:
+                return response
+            jobs.append(response.json())
+        return self._server.json_response(jobs)
+
+    def _handle_list_jobs(self, request: httpx.Request) -> httpx.Response:
+        agent_id = request.url.params.get("extraction_agent_id")
+        items = []
+        for stored in self._jobs.values():
+            if agent_id and stored.job.extraction_agent.id != agent_id:
+                continue
+            items.append(stored.job.dict())
+        return self._server.json_response(items)
+
+    def _handle_get_job(self, request: httpx.Request) -> httpx.Response:
+        job_id = request.url.path.split("/")[-1]
+        stored = self._jobs.get(job_id)
+        if not stored:
+            return self._server.json_response({"detail": "Job not found"}, status_code=404)
+        return self._server.json_response(stored.job.dict())
+
+    def _handle_get_run_by_job(self, request: httpx.Request) -> httpx.Response:
+        job_id = request.url.path.split("/")[-1]
+        stored = self._jobs.get(job_id)
+        if not stored:
+            return self._server.json_response({"detail": "Run not found"}, status_code=404)
+        return self._server.json_response(stored.run.dict())
+
+    def _handle_get_run(self, request: httpx.Request) -> httpx.Response:
+        run_id = request.url.path.split("/")[-1]
+        run = self._runs.get(run_id)
+        if not run:
+            return self._server.json_response({"detail": "Run not found"}, status_code=404)
+        return self._server.json_response(run.dict())
+
+    def _handle_delete_run(self, request: httpx.Request) -> httpx.Response:
+        run_id = request.url.path.split("/")[-1]
+        self._runs.pop(run_id, None)
+        to_delete = [job_id for job_id, stored in self._jobs.items() if stored.run.id == run_id]
+        for job_id in to_delete:
+            self._jobs.pop(job_id, None)
+        return self._server.json_response({}, status_code=200)
+
+    def _handle_list_runs(self, request: httpx.Request) -> httpx.Response:
+        agent_id = request.url.params.get("extraction_agent_id")
+        skip = int(request.url.params.get("skip", "0"))
+        limit = int(request.url.params.get("limit", "50"))
+        filtered = [
+            stored.run
+            for stored in self._jobs.values()
+            if not agent_id or stored.job.extraction_agent.id == agent_id
+        ]
+        page = filtered[skip : skip + limit]
+        response = PaginatedExtractRunsResponse(
+            items=page,
+            skip=skip,
+            limit=limit,
+            total=len(filtered),
+        )
+        return self._server.json_response(response.dict())
+
+    # Internal helpers -----------------------------------------------
+    def _extract_file_info(self, payload: Dict[str, Any], request: httpx.Request) -> StoredFile:
+        if "file_id" in payload:
+            file_id = payload["file_id"]
+            stored = self._files.get(file_id)
+            if not stored:
+                raise ValueError("file_id not found in fake store")
+            return stored
+        if "file" in payload:
+            content, filename = self._files.decode_file_data(payload)
+            file_id = self._server.new_id("file")
+            stored = StoredFile(
+                file=CloudFile(
+                    id=file_id,
+                    name=filename or f"inline-{file_id}",
+                    project_id=request.url.params.get("project_id", self._server.default_project_id),
+                    external_file_id=None,
+                    file_size=len(content),
+                    file_type=None,
+                    created_at=utcnow(),
+                    updated_at=utcnow(),
+                    data_source_id=None,
+                    permission_info=None,
+                    resource_info=None,
+                    last_modified_at=utcnow(),
+                ),
+                content=content,
+                sha256=fingerprint_file(content, filename),
+            )
+            return stored
+        if "text" in payload:
+            text_bytes = payload["text"].encode("utf-8")
+            file_id = self._server.new_id("file")
+            stored = StoredFile(
+                file=CloudFile(
+                    id=file_id,
+                    name=f"text-{file_id}.txt",
+                    project_id=self._server.default_project_id,
+                    external_file_id=None,
+                    file_size=len(text_bytes),
+                    file_type="text/plain",
+                    created_at=utcnow(),
+                    updated_at=utcnow(),
+                    data_source_id=None,
+                    permission_info=None,
+                    resource_info=None,
+                    last_modified_at=utcnow(),
+                ),
+                content=text_bytes,
+                sha256=fingerprint_file(text_bytes, None),
+            )
+            return stored
+        raise ValueError("file payload missing")
+
+    def _build_ephemeral_agent(
+        self,
+        config: ExtractConfig,
+        data_schema: Dict[str, Any],
+        project_id: str,
+    ) -> ExtractAgent:
+        return ExtractAgent(
+            id=self._server.new_id("agent"),
+            name="stateless-agent",
+            config=config,
+            data_schema=data_schema,
+            project_id=project_id,
+            created_at=utcnow(),
+            updated_at=utcnow(),
+            custom_configuration=None,
+        )
+
+    def _generate_run_data(self, schema: Dict[str, Any], file_hash: str) -> Any:
+        seed = combined_seed(file_hash, hash_schema(schema))
+        return generate_data_from_schema(schema, seed)
+
+    def _create_job_and_run(
+        self,
+        *,
+        agent: ExtractAgent,
+        config: ExtractConfig,
+        data_schema: Dict[str, Any],
+        file_info: StoredFile,
+        job_status: StatusEnum,
+        run_status: ExtractState,
+        metadata: Dict[str, Any],
+        data: Any,
+        error: Optional[str],
+        project_id: str,
+    ) -> StoredRun:
+        job_id = self._server.new_id("job")
+        run_id = self._server.new_id("run")
+        now = utcnow()
+
+        job = ExtractJob(
+            id=job_id,
+            file=file_info.file,
+            extraction_agent=agent,
+            status=job_status,
+            error=error,
+        )
+        run = ExtractRun(
+            id=run_id,
+            job_id=job_id,
+            file=file_info.file,
+            extraction_agent_id=agent.id,
+            status=run_status,
+            config=config,
+            data_schema=data_schema,
+            data=data,
+            extraction_metadata=metadata,
+            created_at=now,
+            updated_at=now,
+            from_ui=False,
+            error=error,
+            project_id=project_id,
+        )
+        stored = StoredRun(job=job, run=run)
+        self._jobs[job_id] = stored
+        self._runs[run_id] = run
+        return stored
+
+    def _pop_stub(
+        self,
+        stubs: List[ExtractRunStub],
+        context: RequestContext,
+    ) -> Optional[ExtractRunStub]:
+        for index, stub in enumerate(list(stubs)):
+            if context.matches(stub.matcher):
+                if stub.once:
+                    stubs.pop(index)
+                return stub
+        return None
+
+    def _pop_agent_stub(
+        self,
+        agent_id: str,
+        context: RequestContext,
+    ) -> Optional[AgentRunStub]:
+        for index, stub in enumerate(list(self._agent_run_stubs)):
+            if stub.agent_id != agent_id:
+                continue
+            if context.matches(stub.matcher):
+                if stub.once:
+                    self._agent_run_stubs.pop(index)
+                return stub
+        return None

--- a/py/llama_cloud_services/testing_utils/files.py
+++ b/py/llama_cloud_services/testing_utils/files.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from urllib.parse import urlencode
+
+import httpx
+import respx
+from llama_cloud.types import File as CloudFile
+from llama_cloud.types import FileIdPresignedUrl, PresignedUrl
+
+from ._deterministic import fingerprint_file, hash_chunks, utcnow
+from .matchers import RequestContext, RequestMatcher
+
+if TYPE_CHECKING:
+    from .server import FakeLlamaCloudServer
+
+
+@dataclass(slots=True)
+class StoredFile:
+    file: CloudFile
+    content: bytes
+    sha256: str
+
+
+@dataclass(slots=True)
+class PendingUpload:
+    file_id: str
+    filename: str
+    project_id: str
+    organization_id: str
+    external_file_id: Optional[str]
+    expected_size: Optional[int]
+
+
+class FakeFilesNamespace:
+    def __init__(
+        self,
+        *,
+        server: "FakeLlamaCloudServer",
+        upload_base_url: str,
+        download_base_url: str,
+    ) -> None:
+        self._server = server
+        self._upload_base_url = upload_base_url.rstrip("/")
+        self._download_base_url = download_base_url.rstrip("/")
+        self._files: Dict[str, StoredFile] = {}
+        self._pending: Dict[str, PendingUpload] = {}
+        self._upload_stubs: List[tuple[RequestMatcher | None, int, Dict[str, Any], bool]] = []
+        self.routes: Dict[str, respx.Route] = {}
+
+    # Public helpers -------------------------------------------------
+    def preload(self, *, path: str | Path, filename: Optional[str] = None) -> str:
+        path = Path(path)
+        content = path.read_bytes()
+        file_id = self._server.new_id("file")
+        name = filename or path.name
+        stored = self._build_file(
+            file_id=file_id,
+            name=name,
+            project_id=self._server.default_project_id,
+            organization_id=self._server.default_organization_id,
+            content=content,
+            external_file_id=None,
+        )
+        self._files[file_id] = stored
+        return file_id
+
+    def read(self, file_id: str) -> bytes:
+        return self._files[file_id].content
+
+    def get(self, file_id: str) -> Optional[StoredFile]:
+        return self._files.get(file_id)
+
+    def stub_upload(
+        self,
+        matcher: Optional[RequestMatcher],
+        *,
+        status_code: int = 413,
+        json_body: Optional[Dict[str, Any]] = None,
+        once: bool = True,
+    ) -> None:
+        body = json_body or {"detail": "upload rejected by fake server"}
+        self._upload_stubs.append((matcher, status_code, body, once))
+
+    # Route registration ---------------------------------------------
+    def register(self) -> None:
+        server = self._server
+        server.add_route(
+            "PUT",
+            "/api/v1/files",
+            self._handle_generate_presigned_url,
+            namespace="files",
+            alias="generate_presigned_url",
+        )
+        upload_route = server.add_route(
+            "POST",
+            "/api/v1/files",
+            self._handle_direct_upload,
+            namespace="files",
+            alias="upload",
+        )
+        self.routes["upload"] = upload_route
+        get_route = server.add_route(
+            "GET",
+            "/api/v1/files/{file_id}",
+            self._handle_get_metadata,
+            namespace="files",
+            alias="get",
+        )
+        self.routes["get"] = get_route
+        server.add_route(
+            "DELETE",
+            "/api/v1/files/{file_id}",
+            self._handle_delete,
+            namespace="files",
+        )
+        server.add_route(
+            "GET",
+            "/api/v1/files/{file_id}/content",
+            self._handle_read_content,
+            namespace="files",
+            alias="read_content",
+        )
+        server.add_route(
+            "PUT",
+            "/upload/{file_id}",
+            self._handle_presigned_upload,
+            namespace="files",
+            base_urls=[self._upload_base_url],
+            alias="presigned_upload",
+        )
+        server.add_route(
+            "GET",
+            "/files/{file_id}",
+            self._handle_presigned_download,
+            namespace="files",
+            base_urls=[self._download_base_url],
+            alias="download",
+        )
+
+    # Handlers -------------------------------------------------------
+    def _handle_generate_presigned_url(self, request: httpx.Request) -> httpx.Response:
+        data = self._server.json(request)
+        now = utcnow()
+        file_id = self._server.new_id("file")
+        name = data.get("name") or f"upload-{file_id}.bin"
+        pending = PendingUpload(
+            file_id=file_id,
+            filename=name,
+            project_id=request.url.params.get("project_id", self._server.default_project_id),
+            organization_id=request.url.params.get(
+                "organization_id", self._server.default_organization_id
+            ),
+            external_file_id=data.get("external_file_id"),
+            expected_size=data.get("file_size"),
+        )
+        self._pending[file_id] = pending
+        presigned = FileIdPresignedUrl(
+            file_id=file_id,
+            url=f"{self._upload_base_url}/upload/{file_id}",
+            expires_at=now,
+            form_fields=None,
+        )
+        return self._server.json_response(presigned.dict())
+
+    def _handle_direct_upload(self, request: httpx.Request) -> httpx.Response:
+        file_bytes, filename = self._extract_multipart_file(request)
+        file_id = self._server.new_id("file")
+        stored = self._build_file(
+            file_id=file_id,
+            name=filename or f"upload-{file_id}.bin",
+            project_id=request.url.params.get("project_id", self._server.default_project_id),
+            organization_id=request.url.params.get(
+                "organization_id", self._server.default_organization_id
+            ),
+            content=file_bytes,
+            external_file_id=request.url.params.get("external_file_id"),
+        )
+        self._files[file_id] = stored
+        return self._server.json_response(stored.file.dict())
+
+    def _handle_get_metadata(self, request: httpx.Request) -> httpx.Response:
+        file_id = request.url.path.split("/")[-1]
+        if file_id not in self._files:
+            return self._server.json_response({"detail": "File not found"}, status_code=404)
+        return self._server.json_response(self._files[file_id].file.dict())
+
+    def _handle_delete(self, request: httpx.Request) -> httpx.Response:
+        file_id = request.url.path.split("/")[-1]
+        self._files.pop(file_id, None)
+        self._pending.pop(file_id, None)
+        return self._server.json_response({}, status_code=200)
+
+    def _handle_read_content(self, request: httpx.Request) -> httpx.Response:
+        file_id = request.url.path.split("/")[-2]
+        if file_id not in self._files:
+            return self._server.json_response({"detail": "File not found"}, status_code=404)
+        presigned = PresignedUrl(
+            url=f"{self._download_base_url}/files/{file_id}?{urlencode({'token': 'fake'})}",
+            expires_at=utcnow(),
+            form_fields=None,
+        )
+        return self._server.json_response(presigned.dict())
+
+    def _handle_presigned_upload(self, request: httpx.Request) -> httpx.Response:
+        file_id = request.url.path.split("/")[-1]
+        pending = self._pending.get(file_id)
+
+        context = RequestContext(
+            request=request,
+            json=None,
+            file_id=file_id,
+            filename=pending.filename if pending else None,
+            file_sha256=hash_chunks([request.content]),
+        )
+
+        for index, (matcher, status, body, once) in enumerate(list(self._upload_stubs)):
+            if context.matches(matcher):
+                if once:
+                    self._upload_stubs.pop(index)
+                return self._server.json_response(body, status_code=status)
+
+        if pending is None:
+            return self._server.json_response({"detail": "Unknown file"}, status_code=404)
+
+        stored = self._build_file(
+            file_id=file_id,
+            name=pending.filename,
+            project_id=pending.project_id,
+            organization_id=pending.organization_id,
+            content=request.content,
+            external_file_id=pending.external_file_id,
+        )
+        self._files[file_id] = stored
+        self._pending.pop(file_id, None)
+        return httpx.Response(204)
+
+    def _handle_presigned_download(self, request: httpx.Request) -> httpx.Response:
+        file_id = request.url.path.split("/")[-1]
+        stored = self._files.get(file_id)
+        if not stored:
+            return httpx.Response(404, json={"detail": "File not found"})
+        return httpx.Response(200, content=stored.content)
+
+    # Internal helpers -----------------------------------------------
+    def _build_file(
+        self,
+        *,
+        file_id: str,
+        name: str,
+        project_id: str,
+        organization_id: str,
+        content: bytes,
+        external_file_id: Optional[str],
+    ) -> StoredFile:
+        sha256 = fingerprint_file(content, name)
+        now = utcnow()
+        cloud_file = CloudFile(
+            id=file_id,
+            name=name,
+            project_id=project_id,
+            external_file_id=external_file_id,
+            file_size=len(content),
+            file_type=Path(name).suffix or "application/octet-stream",
+            created_at=now,
+            updated_at=now,
+            data_source_id=None,
+            permission_info=None,
+            resource_info=None,
+            last_modified_at=now,
+        )
+        return StoredFile(file=cloud_file, content=content, sha256=sha256)
+
+    def _extract_multipart_file(self, request: httpx.Request) -> tuple[bytes, Optional[str]]:
+        content_type = request.headers.get("content-type", "")
+        if "multipart/form-data" not in content_type:
+            raise ValueError("Expected multipart upload")
+
+        boundary = content_type.split("boundary=")[-1]
+        boundary_bytes = boundary.encode("utf-8")
+        body = request.content
+        delimiter = b"--" + boundary_bytes
+        parts = [part for part in body.split(delimiter) if part.strip(b"\r\n") and part.strip(b"\r\n") != b"--"]
+        for part in parts:
+            headers, _, payload = part.partition(b"\r\n\r\n")
+            header_text = headers.decode("utf-8", errors="ignore")
+            if 'name="upload_file"' in header_text or 'name="file"' in header_text:
+                filename = None
+                if "filename=" in header_text:
+                    filename = (
+                        header_text.split("filename=")[-1]
+                        .strip()
+                        .strip('"')
+                        .strip("'")
+                    )
+                return payload.rstrip(b"\r\n"), filename
+        raise ValueError("upload file part not found")
+
+    def decode_file_data(self, data: Dict[str, Any]) -> tuple[bytes, Optional[str]]:
+        if "file" not in data:
+            raise ValueError("file payload missing")
+        file_payload = data["file"]
+        encoded = file_payload["data"]
+        content = base64.b64decode(encoded)
+        filename = file_payload.get("filename")
+        return content, filename

--- a/py/llama_cloud_services/testing_utils/matchers.py
+++ b/py/llama_cloud_services/testing_utils/matchers.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+import httpx
+
+
+MatcherPredicate = Callable[[httpx.Request], bool]
+
+
+@dataclass(slots=True)
+class FileMatcher:
+    filename: Optional[str] = None
+    sha256: Optional[str] = None
+    file_id: Optional[str] = None
+
+
+@dataclass(slots=True)
+class SchemaMatcher:
+    model: Optional[type] = None
+    schema_hash: Optional[str] = None
+
+
+@dataclass(slots=True)
+class RequestMatcher:
+    file: Optional[FileMatcher | MatcherPredicate] = None
+    schema: Optional[SchemaMatcher] = None
+    agent_id: Optional[str] = None
+    project_id: Optional[str] = None
+    organization_id: Optional[str] = None
+    predicate: Optional[MatcherPredicate] = None
+
+
+@dataclass(slots=True)
+class RequestContext:
+    request: httpx.Request
+    json: Optional[dict[str, Any]]
+    file_id: Optional[str] = None
+    filename: Optional[str] = None
+    file_sha256: Optional[str] = None
+    schema_hash: Optional[str] = None
+    agent_id: Optional[str] = None
+    project_id: Optional[str] = None
+    organization_id: Optional[str] = None
+
+    def matches(self, matcher: Optional[RequestMatcher]) -> bool:
+        if matcher is None:
+            return True
+
+        if matcher.project_id and matcher.project_id != self.project_id:
+            return False
+
+        if matcher.organization_id and matcher.organization_id != self.organization_id:
+            return False
+
+        if matcher.agent_id and matcher.agent_id != self.agent_id:
+            return False
+
+        if matcher.file:
+            if isinstance(matcher.file, FileMatcher):
+                if matcher.file.filename and matcher.file.filename != self.filename:
+                    return False
+                if matcher.file.file_id and matcher.file.file_id != self.file_id:
+                    return False
+                if matcher.file.sha256 and matcher.file.sha256 != self.file_sha256:
+                    return False
+            else:
+                if not matcher.file(self.request):
+                    return False
+
+        if matcher.schema:
+            if matcher.schema.schema_hash and matcher.schema.schema_hash != self.schema_hash:
+                return False
+            if matcher.schema.model and matcher.schema.schema_hash:
+                return matcher.schema.schema_hash == self.schema_hash
+            if matcher.schema.model and matcher.schema.schema_hash is None:
+                expected = _schema_hash_from_model(matcher.schema.model)
+                return expected == self.schema_hash
+
+        if matcher.predicate and not matcher.predicate(self.request):
+            return False
+
+        return True
+
+
+def _schema_hash_from_model(model: type) -> Optional[str]:
+    if hasattr(model, "model_json_schema"):
+        schema = model.model_json_schema()
+    elif hasattr(model, "schema"):
+        schema = model.schema()  # type: ignore[attr-defined]
+    else:
+        return None
+
+    from ._deterministic import hash_schema
+
+    return hash_schema(schema)
+

--- a/py/llama_cloud_services/testing_utils/parse.py
+++ b/py/llama_cloud_services/testing_utils/parse.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict
+
+import httpx
+
+from ._deterministic import generate_text_blob, hash_schema
+
+if TYPE_CHECKING:
+    from .server import FakeLlamaCloudServer
+
+@dataclass(slots=True)
+class ParseJobRecord:
+    job_id: str
+    file_name: str
+    status: str
+    result: Dict[str, Any]
+    content: bytes
+class FakeParseNamespace:
+    def __init__(self, *, server: "FakeLlamaCloudServer") -> None:
+        self._server = server
+        self._jobs: Dict[str, ParseJobRecord] = {}
+        self.routes: Dict[str, Any] = {}
+
+    def register(self) -> None:
+        server = self._server
+        server.add_route(
+            "POST",
+            "/api/parsing/upload",
+            self._handle_upload,
+            namespace="parse",
+        )
+        server.add_route(
+            "GET",
+            "/api/parsing/job/{job_id}",
+            self._handle_job_status,
+            namespace="parse",
+        )
+        server.add_route(
+            "GET",
+            "/api/parsing/job/{job_id}/result/{result_type}",
+            self._handle_job_result,
+            namespace="parse",
+        )
+
+    def _handle_upload(self, request: httpx.Request) -> httpx.Response:
+        file_bytes, filename, form_data = self._split_multipart(request)
+        job_id = self._server.new_id("parse-job")
+        seed = hash_schema({"filename": filename, "form": form_data})
+        page_text = generate_text_blob(seed, sentences=3)
+        pages = [
+            {
+                "page": index + 1,
+                "text": f"{page_text} (page {index + 1})",
+                "md": f"{page_text} (page {index + 1})",
+                "images": [],
+                "charts": [],
+                "tables": [],
+                "layout": [],
+                "items": [],
+                "status": "SUCCESS",
+                "links": [],
+                "width": 8.5,
+                "height": 11.0,
+                "parsingMode": "deterministic",
+                "structuredData": {},
+                "noStructuredContent": False,
+                "noTextContent": False,
+                "isAudioTranscript": False,
+                "durationInSeconds": None,
+                "slideSpeakerNotes": None,
+            }
+            for index in range(1)
+        ]
+        result = {
+            "job_id": job_id,
+            "status": "SUCCESS",
+            "file_name": filename,
+            "is_done": True,
+            "pages": pages,
+            "job_metadata": {"job_pages": len(pages)},
+            "text": "\n\n".join(page["text"] for page in pages),
+            "markdown": "\n\n".join(page["md"] for page in pages),
+            "json": {"pages": pages},
+        }
+        record = ParseJobRecord(
+            job_id=job_id,
+            file_name=filename,
+            status="SUCCESS",
+            result=result,
+            content=file_bytes,
+        )
+        self._jobs[job_id] = record
+        return self._server.json_response({"id": job_id})
+
+    def _handle_job_status(self, request: httpx.Request) -> httpx.Response:
+        job_id = request.url.path.split("/")[-1]
+        job = self._jobs.get(job_id)
+        if not job:
+            return self._server.json_response({"detail": "Job not found"}, status_code=404)
+        return self._server.json_response({"id": job_id, "status": job.status})
+
+    def _handle_job_result(self, request: httpx.Request) -> httpx.Response:
+        job_id = request.url.path.split("/")[-3]
+        job = self._jobs.get(job_id)
+        if not job:
+            return self._server.json_response({"detail": "Result not found"}, status_code=404)
+        return self._server.json_response(job.result)
+
+    def _split_multipart(
+        self, request: httpx.Request
+    ) -> tuple[bytes, str, Dict[str, str]]:
+        content_type = request.headers.get("content-type", "")
+        if "multipart/form-data" not in content_type:
+            raise ValueError("Expected multipart form data for parse upload")
+        boundary = content_type.split("boundary=")[-1]
+        delimiter = f"--{boundary}".encode()
+        closing = f"--{boundary}--".encode()
+        parts = []
+        body = request.content
+        for chunk in body.split(delimiter):
+            chunk = chunk.strip()
+            if not chunk or chunk == closing:
+                continue
+            parts.append(chunk)
+
+        file_bytes = b""
+        filename = "upload.pdf"
+        form_data: Dict[str, str] = {}
+        for part in parts:
+            header_blob, _, payload = part.partition(b"\r\n\r\n")
+            payload = payload.rstrip(b"\r\n")
+            header_text = header_blob.decode("utf-8", errors="ignore")
+            if "filename=" in header_text:
+                filename = (
+                    header_text.split("filename=")[-1].strip().strip('"').strip("'")
+                )
+                file_bytes = payload
+            else:
+                name = (
+                    header_text.split('name="')[-1]
+                    .split('"')[0]
+                    .strip()
+                )
+                form_data[name] = payload.decode("utf-8", errors="ignore")
+        if not file_bytes:
+            raise ValueError("File part missing from multipart payload")
+        return file_bytes, filename, form_data

--- a/py/llama_cloud_services/testing_utils/server.py
+++ b/py/llama_cloud_services/testing_utils/server.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from typing import Any, Callable, Dict, Optional, Sequence
+
+import httpx
+import respx
+
+from .classify import FakeClassifyNamespace
+from .extract import FakeExtractNamespace
+from .files import FakeFilesNamespace
+from .parse import FakeParseNamespace
+
+
+Handler = Callable[[httpx.Request], httpx.Response]
+
+
+class FakeLlamaCloudServer:
+    DEFAULT_BASE_URL = "https://api.cloud.llamaindex.ai"
+    DEFAULT_UPLOAD_BASE = "https://uploads.fake-llama.test"
+    DEFAULT_DOWNLOAD_BASE = "https://downloads.fake-llama.test"
+
+    def __init__(
+        self,
+        *,
+        base_urls: Optional[Sequence[str]] = None,
+        namespaces: Optional[Sequence[str]] = None,
+        upload_base_url: Optional[str] = None,
+        download_base_url: Optional[str] = None,
+        default_project_id: str = "proj-test",
+        default_organization_id: str = "org-test",
+    ) -> None:
+        self.base_urls = tuple(base_urls or (self.DEFAULT_BASE_URL,))
+        selected = namespaces or ("files", "extract", "parse", "classify")
+        self._namespace_names = {name.lower() for name in selected}
+        self._upload_base_url = upload_base_url or self.DEFAULT_UPLOAD_BASE
+        self._download_base_url = download_base_url or self.DEFAULT_DOWNLOAD_BASE
+        self.default_project_id = default_project_id
+        self.default_organization_id = default_organization_id
+        self.router = respx.MockRouter(assert_all_called=False)
+        self._installed = False
+        self._registered = False
+
+        self.files = FakeFilesNamespace(
+            server=self,
+            upload_base_url=self._upload_base_url,
+            download_base_url=self._download_base_url,
+        )
+        self.extract = FakeExtractNamespace(server=self, files=self.files)
+        self.parse = FakeParseNamespace(server=self)
+        self.classify = FakeClassifyNamespace(server=self, files=self.files)
+
+    # Context management ----------------------------------------------
+    def install(self) -> "FakeLlamaCloudServer":
+        if not self._registered:
+            self._register_namespaces()
+        if not self._installed:
+            self.router.__enter__()
+            self._installed = True
+        return self
+
+    def uninstall(self) -> None:
+        if self._installed:
+            self.router.__exit__(None, None, None)
+            self._installed = False
+
+    def __enter__(self) -> "FakeLlamaCloudServer":
+        return self.install()
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.uninstall()
+
+    # Route utilities -------------------------------------------------
+    def add_route(
+        self,
+        method: str,
+        path: str,
+        handler: Handler,
+        *,
+        namespace: str,
+        alias: Optional[str] = None,
+        base_urls: Optional[Sequence[str]] = None,
+    ) -> respx.Route:
+        urls = base_urls or self.base_urls
+        first_route: Optional[respx.Route] = None
+        for base in urls:
+            route = self._register_route(method, base, path, handler)
+            if first_route is None:
+                first_route = route
+        if alias and first_route:
+            setattr(self, alias, first_route)
+        return first_route  # type: ignore[return-value]
+
+    def _register_route(
+        self,
+        method: str,
+        base: str,
+        path: str,
+        handler: Handler,
+    ) -> respx.Route:
+        url = self._build_url(base, path)
+        if "{" in path:
+            regex = self._compile_regex(base, path)
+            route = self.router.route(method=method, url__regex=regex)
+        else:
+            route = self.router.route(method=method, url=url)
+        route.mock(side_effect=lambda request, func=handler: func(request))
+        return route
+
+    def _build_url(self, base: str, path: str) -> str:
+        base = base.rstrip("/")
+        if not path.startswith("/"):
+            path = "/" + path
+        return f"{base}{path}"
+
+    def _compile_regex(self, base: str, path: str) -> re.Pattern[str]:
+        escaped = re.escape(base.rstrip("/"))
+        regex_path = re.sub(r"\{[^/]+\}", r"[^/]+", path)
+        pattern = f"^{escaped}{regex_path}$"
+        return re.compile(pattern)
+
+    # Helpers ---------------------------------------------------------
+    def json(self, request: httpx.Request) -> Dict[str, Any]:
+        if not request.content:
+            return {}
+        return json.loads(request.content.decode("utf-8"))
+
+    def encode_json(self, payload: Dict[str, Any]) -> bytes:
+        return json.dumps(payload).encode("utf-8")
+
+    def json_response(self, payload: Any, *, status_code: int = 200) -> httpx.Response:
+        body = json.dumps(payload, default=self._json_default).encode("utf-8")
+        headers = {"content-type": "application/json"}
+        return httpx.Response(status_code=status_code, headers=headers, content=body)
+
+    def new_id(self, prefix: str) -> str:
+        return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+    # Internal --------------------------------------------------------
+    def _json_default(self, value: Any) -> Any:
+        if hasattr(value, "model_dump"):
+            return value.model_dump()
+        if hasattr(value, "dict"):
+            return value.dict()
+        if isinstance(value, (set, frozenset)):
+            return list(value)
+        if isinstance(value, (bytes, bytearray)):
+            return value.decode("utf-8")
+        if hasattr(value, "isoformat"):
+            try:
+                return value.isoformat()  # datetime/date support
+            except Exception:
+                pass
+        raise TypeError(f"{value!r} is not JSON serializable")
+
+    def _register_namespaces(self) -> None:
+        if "files" in self._namespace_names:
+            self.files.register()
+        if "extract" in self._namespace_names:
+            self.extract.register()
+        if "parse" in self._namespace_names:
+            self.parse.register()
+        if "classify" in self._namespace_names:
+            self.classify.register()
+        self._registered = True
+
+
+__all__ = ["FakeLlamaCloudServer"]
+

--- a/py/testing_utils_spec.md
+++ b/py/testing_utils_spec.md
@@ -320,3 +320,10 @@ The current Python SDK (`py/llama_cloud_services/extract/extract.py`) is a thin 
 - **Error simulation hooks**: overrides should let us short-circuit any endpoint (jobs, runs, schema validation) without changing SDK code, mirroring how the real API might fail.
 
 This map should serve as the checklist when we implement the mock: if an SDK method calls a certain path, our fake server must expose the same path with compatible request/response bodies so we can eventually lift these utilities into a standalone package.
+
+## Implementation status
+
+- `FakeLlamaCloudServer` now lives in `llama_cloud_services.testing_utils` and registers the files, extract, parse, and classify namespaces by default. It can be used as `with FakeLlamaCloudServer(): ...` or by calling `install()` / `uninstall()` explicitly.
+- Deterministic payloads derive from file fingerprints plus schema hashes for extraction, seeded layout information for parse, and rule/file hashes for classification. The helper exposes matcher-driven overrides (`stub_run`, `stub_agent_run`, `files.stub_upload`) so tests can simulate errors.
+- Common `respx.Route` handles are exposed via namespaces (`fake.extract.stateless_run`, `fake.extract.agent_job`, `fake.files.routes["upload"]`, etc.) for assertions that mirror the examples in this spec.
+- End-to-end usage is covered in `py/unit_tests/testing_utils/test_fake_server.py`, which exercises stateless extraction, agent-backed uploads, and LlamaParse readers entirely against the fake server without external network calls.

--- a/py/unit_tests/testing_utils/test_fake_server.py
+++ b/py/unit_tests/testing_utils/test_fake_server.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from llama_cloud import ExtractConfig
+from llama_cloud.types import ExtractMode
+from llama_cloud_services.extract import LlamaExtract
+from llama_cloud_services.parse import LlamaParse
+from llama_cloud_services.testing_utils import FakeLlamaCloudServer
+from pydantic import BaseModel, Field
+
+
+class Receipt(BaseModel):
+    merchant: str = Field(description="Vendor name")
+    total: float = Field(description="Grand total")
+
+
+@pytest.fixture(autouse=True)
+def _fake_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLAMA_CLOUD_API_KEY", "unit-test-key")
+    monkeypatch.setenv("LLAMA_CLOUD_BASE_URL", FakeLlamaCloudServer.DEFAULT_BASE_URL)
+
+
+@pytest.fixture
+def fake_server() -> FakeLlamaCloudServer:
+    with FakeLlamaCloudServer() as server:
+        yield server
+
+
+def _write_sample_file(tmp_path: Path, name: str, content: str) -> Path:
+    target = tmp_path / name
+    target.write_text(content)
+    return target
+
+
+def test_stateless_extract_is_deterministic(fake_server: FakeLlamaCloudServer, tmp_path: Path) -> None:
+    extractor = LlamaExtract(api_key="unit-test-key", verify=False)
+    config = ExtractConfig(extraction_mode=ExtractMode.FAST)
+    sample_path = _write_sample_file(tmp_path, "receipt.txt", "Merchant: Lunar Bistro\nTotal: 123.45")
+
+    first_run = extractor.extract(Receipt, config, sample_path)
+    second_run = extractor.extract(Receipt, config, sample_path)
+
+    assert first_run.status.value == "SUCCESS"
+    assert second_run.data == first_run.data
+    assert "merchant" in first_run.data
+    assert fake_server.extract.stateless_run.called
+
+
+def test_agent_flow_uploads_and_processes_files(fake_server: FakeLlamaCloudServer, tmp_path: Path) -> None:
+    extractor = LlamaExtract(api_key="unit-test-key", verify=False)
+    config = ExtractConfig(extraction_mode=ExtractMode.FAST)
+    agent = extractor.create_agent(name="unit-test-agent", data_schema=Receipt, config=config)
+
+    sample_path = _write_sample_file(tmp_path, "contract.pdf", "Agreement between parties.")
+    run = agent.extract(sample_path)
+
+    assert run.status.value == "SUCCESS"
+    assert "merchant" in run.data
+
+    uploaded_bytes = fake_server.files.read(run.file.id)
+    assert uploaded_bytes.startswith(b"Agreement")
+    assert fake_server.extract.agent_job.called
+    assert fake_server.extract.agent_run.called
+
+
+def test_parse_load_data_returns_documents(fake_server: FakeLlamaCloudServer, tmp_path: Path) -> None:
+    parser = LlamaParse(api_key="unit-test-key", base_url=FakeLlamaCloudServer.DEFAULT_BASE_URL)
+    sample_path = _write_sample_file(tmp_path, "report.pdf", "Executive summary of quarterly goals.")
+
+    documents = parser.load_data(sample_path)
+
+    assert documents
+    assert "(page 1)" in documents[0].text


### PR DESCRIPTION
Implement `FakeLlamaCloudServer` to provide a fully mocked environment for Llama Cloud SDK extract and parse tests.

This PR introduces a `FakeLlamaCloudServer` that simulates the Llama Cloud API for files, extract, parse, and classify namespaces. It enables realistic, fully mocked end-to-end tests for the SDK, featuring deterministic data generation, in-memory file handling, and stub hooks to simulate various API responses and errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f9820e6-a7b9-4545-b07e-fd85fdfc93d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f9820e6-a7b9-4545-b07e-fd85fdfc93d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

