### PR TITLE
fix: change ImageItem original_width/height type from int to float

### DIFF
--- a/py/llama_cloud_services/parse/types.py
+++ b/py/llama_cloud_services/parse/types.py
@@ -177,10 +177,10 @@ class ImageItem(SafeBaseModel):
     y: Optional[float] = Field(
         default=None, description="The y-coordinate of the image."
     )
-    original_width: Optional[int] = Field(
+    original_width: Optional[float] = Field(
         default=None, description="The original width of the image."
     )
-    original_height: Optional[int] = Field(
+    original_height: Optional[float] = Field(
         default=None, description="The original height of the image."
     )
     type: Optional[str] = Field(default=None, description="The type of the image.")


### PR DESCRIPTION
Fixes #1078

## Summary
The agentic parsing mode (`parse_page_with_agent`) returns float values for `original_width` and `original_height` in `ImageItem`, causing Pydantic validation errors.

## Cause
The agentic pipeline performs coordinate calculations that produce float values, while the SDK type annotations expected integers.

## Solution
Change the field types from `Optional[int]` to `Optional[float]`. This accepts both int and float values without losing precision.

Note: For users of the fast mode (`parse_page_without_llm`), integer values like `2320` will now be represented as `2320.0`. This is a minor cosmetic change with no functional impact.