### PR TITLE
Llamaparse heartbeat timeout retry

### DIFF
--- a/py/llama_cloud_services/parse/__init__.py
+++ b/py/llama_cloud_services/parse/__init__.py
@@ -4,5 +4,16 @@ from llama_cloud_services.parse.base import (
     ParsingMode,
     FailedPageMode,
 )
+from llama_cloud_services.parse.temporal import (
+    is_heartbeat_timeout_error,
+    retry_on_heartbeat_timeout,
+)
 
-__all__ = ["LlamaParse", "ResultType", "ParsingMode", "FailedPageMode"]
+__all__ = [
+    "LlamaParse",
+    "ResultType",
+    "ParsingMode",
+    "FailedPageMode",
+    "is_heartbeat_timeout_error",
+    "retry_on_heartbeat_timeout",
+]

--- a/py/llama_cloud_services/parse/temporal.py
+++ b/py/llama_cloud_services/parse/temporal.py
@@ -1,0 +1,130 @@
+"""Utilities for retrying LlamaParse activities in Temporal
+specifically when they fail due to activity heartbeat timeout.
+
+These utilities detect Temporal's ActivityError wrapping a TimeoutError
+with timeout_type HEARTBEAT, without requiring a direct dependency on the
+Temporal SDK.
+
+Usage in a Temporal workflow::
+
+    from temporalio import workflow
+    from llama_cloud_services.parse.temporal import retry_on_heartbeat_timeout
+
+    @workflow.defn
+    class ParseWorkflow:
+        @workflow.run
+        async def run(self, input: ParseInput) -> ParseResult:
+            parse_activity = workflow.start_activity(
+                "llama_parse",
+                input,
+                start_to_close_timeout=timedelta(minutes=30),
+                heartbeat_timeout=timedelta(seconds=60),
+                retry_policy=RetryPolicy(maximum_attempts=1),  # disable built-in retry
+            )
+            return await retry_on_heartbeat_timeout(parse_activity)
+"""
+
+import logging
+from typing import Any, Awaitable, Callable, Optional, TypeVar
+
+T = TypeVar("T")
+logger = logging.getLogger(__name__)
+
+# Temporal TimeoutType enum value for HEARTBEAT (from temporalio proto)
+_TIMEOUT_TYPE_HEARTBEAT = 4
+
+
+def is_heartbeat_timeout_error(error: BaseException) -> bool:
+    """Check if an error is a Temporal activity heartbeat timeout error.
+
+    Detects both the structured Temporal error types (ActivityError wrapping
+    TimeoutError with timeout_type HEARTBEAT) and fallback string matching
+    on the error message.
+
+    Works with the ``temporalio`` Python SDK error types without requiring
+    a direct import.
+
+    Args:
+        error: The exception to check.
+
+    Returns:
+        True if the error represents a heartbeat timeout.
+    """
+    error_type_name = type(error).__name__
+
+    # Check for Temporal's ActivityError → TimeoutError chain
+    if error_type_name in ("ActivityError", "ActivityFailure"):
+        cause = getattr(error, "cause", None) or error.__cause__
+        if cause is not None:
+            cause_type_name = type(cause).__name__
+            if cause_type_name in ("TimeoutError", "TimeoutFailure"):
+                timeout_type = getattr(cause, "type", None) or getattr(
+                    cause, "timeout_type", None
+                )
+                if timeout_type is not None:
+                    # Handle both enum and int representations
+                    timeout_type_val = (
+                        timeout_type.value
+                        if hasattr(timeout_type, "value")
+                        else timeout_type
+                    )
+                    return timeout_type_val == _TIMEOUT_TYPE_HEARTBEAT
+
+    # Fallback: match on error message
+    message = str(error).lower()
+    return "heartbeat timeout" in message or "heartbeat_timeout" in message
+
+
+async def retry_on_heartbeat_timeout(
+    fn: Callable[..., Awaitable[T]],
+    *args: Any,
+    max_retries: int = 3,
+    on_retry: Optional[Callable[[int, BaseException], None]] = None,
+    **kwargs: Any,
+) -> T:
+    """Retry an async function only when it fails with a heartbeat timeout error.
+
+    All other errors are raised immediately without retry.
+
+    Designed for use in Temporal workflows to wrap activity calls so that
+    transient heartbeat timeouts (e.g. from SIGTERM, event-loop blocking)
+    are automatically retried while genuine failures propagate immediately.
+
+    Args:
+        fn: The async function to execute (typically a Temporal activity call).
+        *args: Positional arguments passed to ``fn``.
+        max_retries: Maximum number of retry attempts after the initial try
+            (default: 3).
+        on_retry: Optional callback invoked before each retry with the attempt
+            number and the error.
+        **kwargs: Keyword arguments passed to ``fn``.
+
+    Returns:
+        The result of the function.
+
+    Raises:
+        The original exception if it is not a heartbeat timeout or retries
+        are exhausted.
+    """
+    last_error: Optional[BaseException] = None
+
+    for attempt in range(max_retries + 1):
+        try:
+            return await fn(*args, **kwargs)
+        except BaseException as err:
+            last_error = err
+            if is_heartbeat_timeout_error(err) and attempt < max_retries:
+                logger.warning(
+                    "LlamaParse activity failed with heartbeat timeout "
+                    "(attempt %d/%d), retrying...",
+                    attempt + 1,
+                    max_retries,
+                )
+                if on_retry:
+                    on_retry(attempt + 1, err)
+                continue
+            raise
+
+    # Should not reach here, but satisfy type checker
+    assert last_error is not None
+    raise last_error

--- a/py/unit_tests/parse/test_temporal.py
+++ b/py/unit_tests/parse/test_temporal.py
@@ -1,0 +1,191 @@
+import pytest
+
+from llama_cloud_services.parse.temporal import (
+    is_heartbeat_timeout_error,
+    retry_on_heartbeat_timeout,
+)
+
+
+class FakeTimeoutError(Exception):
+    """Mimics temporalio.exceptions.TimeoutError with a type attribute."""
+
+    def __init__(self, timeout_type):
+        super().__init__("timeout")
+        self.type = timeout_type
+
+
+class FakeTimeoutType:
+    """Mimics temporalio.exceptions.TimeoutType enum."""
+
+    HEARTBEAT = 4
+    START_TO_CLOSE = 1
+
+
+class FakeActivityError(Exception):
+    """Mimics temporalio.exceptions.ActivityError with a cause."""
+
+    def __init__(self, cause=None):
+        super().__init__("activity error")
+        self.__cause__ = cause
+
+
+# Make the class names match what the code checks
+FakeTimeoutError.__name__ = "TimeoutError"
+FakeActivityError.__name__ = "ActivityError"
+
+
+class TestIsHeartbeatTimeoutError:
+    def test_detects_activity_error_with_heartbeat_timeout(self):
+        timeout_err = FakeTimeoutError(FakeTimeoutType.HEARTBEAT)
+        activity_err = FakeActivityError(cause=timeout_err)
+        assert is_heartbeat_timeout_error(activity_err) is True
+
+    def test_rejects_activity_error_with_start_to_close_timeout(self):
+        timeout_err = FakeTimeoutError(FakeTimeoutType.START_TO_CLOSE)
+        activity_err = FakeActivityError(cause=timeout_err)
+        assert is_heartbeat_timeout_error(activity_err) is False
+
+    def test_rejects_activity_error_with_non_timeout_cause(self):
+        other_err = ValueError("some other error")
+        activity_err = FakeActivityError(cause=other_err)
+        assert is_heartbeat_timeout_error(activity_err) is False
+
+    def test_detects_heartbeat_timeout_from_message(self):
+        err = Exception("activity Heartbeat timeout")
+        assert is_heartbeat_timeout_error(err) is True
+
+    def test_detects_heartbeat_timeout_underscore_from_message(self):
+        err = Exception("Failed due to heartbeat_timeout")
+        assert is_heartbeat_timeout_error(err) is True
+
+    def test_rejects_non_heartbeat_errors(self):
+        err = Exception("Connection refused")
+        assert is_heartbeat_timeout_error(err) is False
+
+    def test_handles_none_error(self):
+        assert is_heartbeat_timeout_error(ValueError()) is False
+
+    def test_detects_heartbeat_timeout_with_enum_value_attr(self):
+        """Test with an enum-like type that has .value."""
+
+        class EnumLike:
+            value = 4
+
+        timeout_err = FakeTimeoutError(EnumLike())
+        activity_err = FakeActivityError(cause=timeout_err)
+        assert is_heartbeat_timeout_error(activity_err) is True
+
+
+class TestRetryOnHeartbeatTimeout:
+    @pytest.mark.asyncio
+    async def test_returns_result_on_success(self):
+        async def success():
+            return "ok"
+
+        result = await retry_on_heartbeat_timeout(success)
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_retries_on_heartbeat_timeout(self):
+        call_count = 0
+
+        async def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                timeout_err = FakeTimeoutError(FakeTimeoutType.HEARTBEAT)
+                raise FakeActivityError(cause=timeout_err)
+            return "recovered"
+
+        result = await retry_on_heartbeat_timeout(flaky, max_retries=3)
+        assert result == "recovered"
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_on_non_heartbeat_errors(self):
+        call_count = 0
+
+        async def always_fail():
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("Application error")
+
+        with pytest.raises(ValueError, match="Application error"):
+            await retry_on_heartbeat_timeout(always_fail)
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_exhausts_retries_on_persistent_heartbeat_timeout(self):
+        call_count = 0
+
+        async def always_heartbeat_timeout():
+            nonlocal call_count
+            call_count += 1
+            timeout_err = FakeTimeoutError(FakeTimeoutType.HEARTBEAT)
+            raise FakeActivityError(cause=timeout_err)
+
+        with pytest.raises(FakeActivityError):
+            await retry_on_heartbeat_timeout(
+                always_heartbeat_timeout, max_retries=2
+            )
+        assert call_count == 3  # initial + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_calls_on_retry_callback(self):
+        retries_seen = []
+
+        def on_retry(attempt, error):
+            retries_seen.append(attempt)
+
+        call_count = 0
+
+        async def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                timeout_err = FakeTimeoutError(FakeTimeoutType.HEARTBEAT)
+                raise FakeActivityError(cause=timeout_err)
+            return "ok"
+
+        result = await retry_on_heartbeat_timeout(
+            flaky, max_retries=3, on_retry=on_retry
+        )
+        assert result == "ok"
+        assert retries_seen == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_3_retries(self):
+        call_count = 0
+
+        async def always_heartbeat_timeout():
+            nonlocal call_count
+            call_count += 1
+            timeout_err = FakeTimeoutError(FakeTimeoutType.HEARTBEAT)
+            raise FakeActivityError(cause=timeout_err)
+
+        with pytest.raises(FakeActivityError):
+            await retry_on_heartbeat_timeout(always_heartbeat_timeout)
+        assert call_count == 4  # initial + 3 retries
+
+    @pytest.mark.asyncio
+    async def test_passes_args_and_kwargs(self):
+        async def add(a, b, extra=0):
+            return a + b + extra
+
+        result = await retry_on_heartbeat_timeout(add, 1, 2, extra=10)
+        assert result == 13
+
+    @pytest.mark.asyncio
+    async def test_retries_on_message_match(self):
+        call_count = 0
+
+        async def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("activity Heartbeat timeout")
+            return "recovered"
+
+        result = await retry_on_heartbeat_timeout(flaky, max_retries=3)
+        assert result == "recovered"
+        assert call_count == 2

--- a/ts/llama_cloud_services/package.json
+++ b/ts/llama_cloud_services/package.json
@@ -25,7 +25,8 @@
     "./parse",
     "./beta/agent",
     "./extract",
-    "./classify"
+    "./classify",
+    "./temporal"
   ],
   "exports": {
     "./openapi.json": "./openapi.json",
@@ -94,6 +95,17 @@
         "default": "./classify/dist/index.js"
       },
       "default": "./classify/dist/index.js"
+    },
+    "./temporal": {
+      "require": {
+        "types": "./temporal/dist/index.d.cts",
+        "default": "./temporal/dist/index.cjs"
+      },
+      "import": {
+        "types": "./temporal/dist/index.d.ts",
+        "default": "./temporal/dist/index.js"
+      },
+      "default": "./temporal/dist/index.js"
     },
     ".": {
       "require": {

--- a/ts/llama_cloud_services/src/index.ts
+++ b/ts/llama_cloud_services/src/index.ts
@@ -24,3 +24,8 @@ export type {
   ClassifyJobResults,
   ClassifyParsingConfiguration,
 } from "./classify.js";
+export {
+  isHeartbeatTimeoutError,
+  retryOnHeartbeatTimeout,
+  type RetryOnHeartbeatTimeoutOptions,
+} from "./temporal.js";

--- a/ts/llama_cloud_services/src/temporal.ts
+++ b/ts/llama_cloud_services/src/temporal.ts
@@ -1,0 +1,111 @@
+/**
+ * Utilities for retrying LlamaParse activities in Temporal
+ * specifically when they fail due to activity heartbeat timeout.
+ *
+ * These utilities detect Temporal's ActivityFailure wrapping a TimeoutFailure
+ * with timeoutType HEARTBEAT, without requiring a direct dependency on the
+ * Temporal SDK.
+ *
+ * Usage in a Temporal workflow:
+ *
+ * ```ts
+ * import { retryOnHeartbeatTimeout } from 'llama-cloud-services/temporal';
+ * import { proxyActivities } from '@temporalio/workflow';
+ *
+ * const { llamaParse } = proxyActivities<typeof activities>({
+ *   startToCloseTimeout: '30m',
+ *   heartbeatTimeout: '60s',
+ *   retry: { maximumAttempts: 1 }, // disable built-in retry
+ * });
+ *
+ * export async function parseWorkflow(input: ParseInput): Promise<ParseResult> {
+ *   return retryOnHeartbeatTimeout(() => llamaParse(input), { maxRetries: 3 });
+ * }
+ * ```
+ */
+
+// Temporal TimeoutType enum value for HEARTBEAT (from @temporalio/common proto)
+const TIMEOUT_TYPE_HEARTBEAT = 4;
+
+/**
+ * Checks if an error is a Temporal activity heartbeat timeout error.
+ *
+ * Detects both the structured Temporal error types (ActivityFailure wrapping
+ * TimeoutFailure with timeoutType HEARTBEAT) and fallback string matching
+ * on the error message.
+ */
+export function isHeartbeatTimeoutError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const err = error as Record<string, unknown>;
+
+  // Check for Temporal's ActivityFailure → TimeoutFailure chain
+  if (err.name === "ActivityFailure" || err.name === "ActivityError") {
+    const cause =
+      (err.cause as Record<string, unknown>) ??
+      ((error as { __cause__?: unknown }).__cause__ as Record<string, unknown>);
+
+    if (cause && typeof cause === "object") {
+      const causeName = (cause as Record<string, unknown>).name;
+      if (causeName === "TimeoutFailure" || causeName === "TimeoutError") {
+        const timeoutType = (cause as Record<string, unknown>).timeoutType;
+        return (
+          timeoutType === TIMEOUT_TYPE_HEARTBEAT ||
+          timeoutType === "HEARTBEAT" ||
+          timeoutType === "TimeoutType.HEARTBEAT"
+        );
+      }
+    }
+  }
+
+  // Fallback: match on error message
+  const message = String(
+    (err as { message?: string }).message ?? String(err),
+  ).toLowerCase();
+  return (
+    message.includes("heartbeat timeout") ||
+    message.includes("heartbeat_timeout")
+  );
+}
+
+export interface RetryOnHeartbeatTimeoutOptions {
+  /** Maximum number of retry attempts after the initial try (default: 3). */
+  maxRetries?: number;
+  /** Optional callback invoked before each retry with the attempt number and error. */
+  onRetry?: (attempt: number, error: unknown) => void;
+}
+
+/**
+ * Retries an async function only when it fails with a heartbeat timeout error.
+ * All other errors are thrown immediately without retry.
+ *
+ * Designed for use in Temporal workflows to wrap activity calls so that
+ * transient heartbeat timeouts (e.g. from SIGTERM, event-loop blocking)
+ * are automatically retried while genuine failures propagate immediately.
+ *
+ * @param fn - The async function to execute (typically a Temporal activity call)
+ * @param options - Retry configuration
+ * @returns The result of the function
+ */
+export async function retryOnHeartbeatTimeout<T>(
+  fn: () => Promise<T>,
+  options: RetryOnHeartbeatTimeoutOptions = {},
+): Promise<T> {
+  const { maxRetries = 3, onRetry } = options;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (isHeartbeatTimeoutError(err) && attempt < maxRetries) {
+        onRetry?.(attempt + 1, err);
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  throw lastError;
+}

--- a/ts/llama_cloud_services/temporal/package.json
+++ b/ts/llama_cloud_services/temporal/package.json
@@ -1,0 +1,8 @@
+{
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": "./dist/index.js",
+  "private": true
+}

--- a/ts/llama_cloud_services/tests/temporal.test.ts
+++ b/ts/llama_cloud_services/tests/temporal.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  isHeartbeatTimeoutError,
+  retryOnHeartbeatTimeout,
+} from "../src/temporal.js";
+
+describe("Temporal Heartbeat Timeout Utilities", () => {
+  describe("isHeartbeatTimeoutError", () => {
+    it("should detect ActivityFailure wrapping TimeoutFailure with HEARTBEAT type (numeric)", () => {
+      const error = {
+        name: "ActivityFailure",
+        message: "activity failed",
+        cause: {
+          name: "TimeoutFailure",
+          message: "timeout",
+          timeoutType: 4,
+        },
+      };
+      expect(isHeartbeatTimeoutError(error)).toBe(true);
+    });
+
+    it("should detect ActivityFailure wrapping TimeoutFailure with HEARTBEAT type (string)", () => {
+      const error = {
+        name: "ActivityFailure",
+        message: "activity failed",
+        cause: {
+          name: "TimeoutFailure",
+          message: "timeout",
+          timeoutType: "HEARTBEAT",
+        },
+      };
+      expect(isHeartbeatTimeoutError(error)).toBe(true);
+    });
+
+    it("should detect ActivityError wrapping TimeoutError with HEARTBEAT type", () => {
+      const error = {
+        name: "ActivityError",
+        message: "activity error",
+        cause: {
+          name: "TimeoutError",
+          message: "timeout",
+          timeoutType: 4,
+        },
+      };
+      expect(isHeartbeatTimeoutError(error)).toBe(true);
+    });
+
+    it("should reject ActivityFailure with non-heartbeat timeout type", () => {
+      const error = {
+        name: "ActivityFailure",
+        message: "activity failed",
+        cause: {
+          name: "TimeoutFailure",
+          message: "timeout",
+          timeoutType: 1, // START_TO_CLOSE
+        },
+      };
+      expect(isHeartbeatTimeoutError(error)).toBe(false);
+    });
+
+    it("should reject ActivityFailure with non-timeout cause", () => {
+      const error = {
+        name: "ActivityFailure",
+        message: "activity failed",
+        cause: {
+          name: "ApplicationFailure",
+          message: "app error",
+        },
+      };
+      expect(isHeartbeatTimeoutError(error)).toBe(false);
+    });
+
+    it("should detect heartbeat timeout from error message", () => {
+      const error = new Error("activity Heartbeat timeout");
+      expect(isHeartbeatTimeoutError(error)).toBe(true);
+    });
+
+    it("should detect heartbeat_timeout in error message", () => {
+      const error = new Error("Failed due to heartbeat_timeout");
+      expect(isHeartbeatTimeoutError(error)).toBe(true);
+    });
+
+    it("should reject non-heartbeat errors", () => {
+      const error = new Error("Connection refused");
+      expect(isHeartbeatTimeoutError(error)).toBe(false);
+    });
+
+    it("should handle null/undefined", () => {
+      expect(isHeartbeatTimeoutError(null)).toBe(false);
+      expect(isHeartbeatTimeoutError(undefined)).toBe(false);
+    });
+
+    it("should handle non-object errors", () => {
+      expect(isHeartbeatTimeoutError("string error")).toBe(false);
+      expect(isHeartbeatTimeoutError(42)).toBe(false);
+    });
+  });
+
+  describe("retryOnHeartbeatTimeout", () => {
+    it("should return result on success", async () => {
+      const fn = vi.fn().mockResolvedValue("success");
+      const result = await retryOnHeartbeatTimeout(fn);
+      expect(result).toBe("success");
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should retry on heartbeat timeout error", async () => {
+      const heartbeatError = Object.assign(new Error("timeout"), {
+        name: "ActivityFailure",
+        cause: { name: "TimeoutFailure", timeoutType: 4 },
+      });
+
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(heartbeatError)
+        .mockResolvedValue("recovered");
+
+      const result = await retryOnHeartbeatTimeout(fn, { maxRetries: 3 });
+      expect(result).toBe("recovered");
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not retry on non-heartbeat errors", async () => {
+      const appError = new Error("Application error");
+      const fn = vi.fn().mockRejectedValue(appError);
+
+      await expect(retryOnHeartbeatTimeout(fn)).rejects.toThrow(
+        "Application error",
+      );
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should exhaust retries on persistent heartbeat timeout", async () => {
+      const heartbeatError = Object.assign(new Error("timeout"), {
+        name: "ActivityFailure",
+        cause: { name: "TimeoutFailure", timeoutType: 4 },
+      });
+
+      const fn = vi.fn().mockRejectedValue(heartbeatError);
+
+      await expect(
+        retryOnHeartbeatTimeout(fn, { maxRetries: 2 }),
+      ).rejects.toBe(heartbeatError);
+      expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
+    });
+
+    it("should call onRetry callback before each retry", async () => {
+      const heartbeatError = Object.assign(new Error("timeout"), {
+        name: "ActivityFailure",
+        cause: { name: "TimeoutFailure", timeoutType: 4 },
+      });
+
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(heartbeatError)
+        .mockRejectedValueOnce(heartbeatError)
+        .mockResolvedValue("ok");
+
+      const onRetry = vi.fn();
+      const result = await retryOnHeartbeatTimeout(fn, {
+        maxRetries: 3,
+        onRetry,
+      });
+
+      expect(result).toBe("ok");
+      expect(onRetry).toHaveBeenCalledTimes(2);
+      expect(onRetry).toHaveBeenCalledWith(1, heartbeatError);
+      expect(onRetry).toHaveBeenCalledWith(2, heartbeatError);
+    });
+
+    it("should default to 3 retries", async () => {
+      const heartbeatError = Object.assign(new Error("timeout"), {
+        name: "ActivityFailure",
+        cause: { name: "TimeoutFailure", timeoutType: 4 },
+      });
+
+      const fn = vi.fn().mockRejectedValue(heartbeatError);
+
+      await expect(retryOnHeartbeatTimeout(fn)).rejects.toBe(heartbeatError);
+      expect(fn).toHaveBeenCalledTimes(4); // initial + 3 retries
+    });
+
+    it("should detect heartbeat timeout from message and retry", async () => {
+      const messageError = new Error("activity Heartbeat timeout");
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(messageError)
+        .mockResolvedValue("recovered");
+
+      const result = await retryOnHeartbeatTimeout(fn);
+      expect(result).toBe("recovered");
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
Add Temporal heartbeat timeout retry utilities to retry LlamaParse activities only if they failed from an activity heartbeat timeout.

This prevents immediate propagation of other errors while allowing transient heartbeat timeout issues to be retried, improving robustness for long-running activities.

---
[Slack Thread](https://llama-index.slack.com/archives/C078PHNTF44/p1771364831803909?thread_ts=1771364831.803909&cid=C078PHNTF44)

<p><a href="https://cursor.com/background-agent?bcId=bc-760521ff-8ebd-5ba2-baee-40d3480edffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-760521ff-8ebd-5ba2-baee-40d3480edffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

